### PR TITLE
Use import instead of require for koa-bodyparser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/koa": "^2.13.4",
         "@types/koa__cors": "^3.3.0",
         "@types/koa__router": "^8.0.11",
+        "@types/koa-bodyparser": "^4.3.7",
         "@types/koa-jwt": "^3.3.0",
         "@types/koa-logger": "^3.1.2",
         "@types/koa-mount": "^4.0.1",
@@ -1973,6 +1974,15 @@
       "version": "8.0.11",
       "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.11.tgz",
       "integrity": "sha512-WXgKWpBsbS14kzmzD9LeFapOIa678h7zvUHxDwXwSx4ETKXhXLVUAToX6jZ/U7EihM7qwyD9W/BZvB0MRu7MTQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/koa": "*"
+      }
+    },
+    "node_modules/@types/koa-bodyparser": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@types/koa-bodyparser/-/koa-bodyparser-4.3.7.tgz",
+      "integrity": "sha512-21NhEp7LjZm4zbNV5alHHmrNY4J+S7B8lYTO6CzRL8ShTMnl20Gd14dRgVhAxraLaW5iZMofox+BycbuiDvj2Q==",
       "dev": true,
       "dependencies": {
         "@types/koa": "*"
@@ -14213,6 +14223,15 @@
       "version": "8.0.11",
       "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.11.tgz",
       "integrity": "sha512-WXgKWpBsbS14kzmzD9LeFapOIa678h7zvUHxDwXwSx4ETKXhXLVUAToX6jZ/U7EihM7qwyD9W/BZvB0MRu7MTQ==",
+      "dev": true,
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
+    "@types/koa-bodyparser": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@types/koa-bodyparser/-/koa-bodyparser-4.3.7.tgz",
+      "integrity": "sha512-21NhEp7LjZm4zbNV5alHHmrNY4J+S7B8lYTO6CzRL8ShTMnl20Gd14dRgVhAxraLaW5iZMofox+BycbuiDvj2Q==",
       "dev": true,
       "requires": {
         "@types/koa": "*"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/koa": "^2.13.4",
     "@types/koa__cors": "^3.3.0",
     "@types/koa__router": "^8.0.11",
+    "@types/koa-bodyparser": "^4.3.7",
     "@types/koa-jwt": "^3.3.0",
     "@types/koa-logger": "^3.1.2",
     "@types/koa-mount": "^4.0.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 // import { port } from '@src/configuration';
 import Koa from 'koa';
 import KoaRouter from '@koa/router';
-const bodyParser = require('koa-bodyparser');
+import bodyParser from 'koa-bodyparser';
 import { RegisterRoutes } from './routes';
 // import { koaSwagger } from 'koa2-swagger-ui';
 // import KoaMount from 'koa-mount';


### PR DESCRIPTION
This PR fixes a formatting issue where I had originally used a require statement to load bodyparser. I converted it to an import and also installed koa-bodyparser types to make that work. 