### PR TITLE
Set up for debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach FantasyStats",
+      "type": "node",
+      "request": "attach",
+      "restart": true,
+      "port": 9229,
+      "address": "localhost",
+      "remoteRoot": "/source"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev:fresh": "npm run build && npm run dev:docker && node ./dist/app.js",
     "dev": "npm run build && npm run start",
-    "start": "node ./dist/app.js",
+    "start": "node --inspect=0.0.0.0 ./dist/app.js",
     "build": "tsoa spec-and-routes && tsc -b tsconfig.build.json",
     "dev:watch": "nodemon --ignore src/routes.ts -e 'ts' -i '**/*.test.ts' -w 'src/*' -x 'npm run dev'",
     "dev:docker": "docker-compose kill && docker-compose rm -f && docker-compose down -v && docker-compose build && docker-compose up -d",


### PR DESCRIPTION
This PR adds a launch configuration and the `--inspect` flag on the node command at startup. The result is that debugging is possible. 

Run `npm run dev:watch` and wait for the app to come up
Navigate to the 'Run and Debug' panel, select 'Attach FantasyStats', and press play
Place a breakpoint in the code
Trigger a request that hits that breakpoint
Your breakpoint should be hit