### PR TITLE
Add swagger UI to document and test api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "koa-static": "^5.0.0",
         "koa2-swagger-ui": "^5.5.1",
         "pg": "^8.7.3",
+        "swagger-ui-dist": "^4.14.0",
         "tsoa": "^4.1.0",
         "uuid": "^8.3.2"
       },
@@ -10528,6 +10529,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.14.0.tgz",
+      "integrity": "sha512-TBzhheU15s+o54Cgk9qxuYcZMiqSm/SkvKnapoGHOF66kz0Y5aGjpzj5BT/vpBbn6rTPJ9tUYXQxuDWfsjiGMw=="
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -19478,6 +19484,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "swagger-ui-dist": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.14.0.tgz",
+      "integrity": "sha512-TBzhheU15s+o54Cgk9qxuYcZMiqSm/SkvKnapoGHOF66kz0Y5aGjpzj5BT/vpBbn6rTPJ9tUYXQxuDWfsjiGMw=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "koa-static": "^5.0.0",
     "koa2-swagger-ui": "^5.5.1",
     "pg": "^8.7.3",
+    "swagger-ui-dist": "^4.14.0",
     "tsoa": "^4.1.0",
     "uuid": "^8.3.2"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,16 +3,12 @@ import Koa from 'koa';
 import KoaRouter from '@koa/router';
 import bodyParser from 'koa-bodyparser';
 import { RegisterRoutes } from './routes';
-// import { koaSwagger } from 'koa2-swagger-ui';
-// import KoaMount from 'koa-mount';
-// import KoaServe from 'koa-static';
+import { koaSwagger } from 'koa2-swagger-ui';
+import KoaMount from 'koa-mount';
+import KoaServe from 'koa-static';
+import * as fs from 'node:fs';
 
 export class App {
-  // async createLeague(leagueName: string): Promise<League> {
-  //   const repo = new PgStatsRepository();
-  //   return await repo.createLeague(leagueName);
-  // }
-
   run(): void {
     const app: Koa = new Koa();
     app.use(bodyParser());
@@ -22,30 +18,24 @@ export class App {
     app.use(router.routes()).use(router.allowedMethods());
     console.log(`anybody out there? port: ${port}`);
 
-    // this.enableSwaggerDocs(app);
-
-    // app.use(async (context: Koa.Context) => {
-    //   context.body = 'hello world';
-    // });
+    this.enableSwaggerDocs(app);
   }
 
-  // private enableSwaggerDocs(app: Koa) {
-  //   app.use(koaSwagger({
-  //       routePrefix: "docs",
-  //       swaggerOptions: {
-  //           url: 'spec',
-  //       },
-  //       hideTopbar: true,
-  //       title: 'FantasyStats API',
-  //       favicon: 'https://www.physna.com/assets/images/icon/favicon-32x32.png',
-  //       // oauthOptions: {
-  //       //     usePkceWithAuthorizationCodeGrant: true,
-  //       //     clientId: process.env.oktaOauthClientId,
-  //       //     scopes: ["tenant"]
-  //       // },
-  //   }));
-  //   app.use(KoaMount('/', KoaServe('./node_modules/swagger-ui-dist')));
-  // }
+  private enableSwaggerDocs(app: Koa) {
+    const spec = fs.readFileSync('swagger.json').toString();
+
+    app.use(
+      koaSwagger({
+        routePrefix: '/swagger',
+        swaggerOptions: {
+          spec: JSON.parse(spec),
+        },
+        hideTopbar: true,
+        title: 'FantasyStats API',
+      })
+    );
+    app.use(KoaMount('/', KoaServe('./node_modules/swagger-ui-dist')));
+  }
 }
 
 const app = new App();


### PR DESCRIPTION
### What
This PR adds [Swagger UI](https://swagger.io/tools/swagger-ui/) to the project. This allows me to create fluid documentation and more easily fire off test requests.

### Details
Bring up the app as normal, `npm run dev:watch` for example, and navigate to `http://localhost:9090/swagger`. This is configured in the private `enableSwaggerDocs` function. `swagger.json` powers the spec, and that file should automatically be updated every time the controllers are edited.