### PR TITLE
add package.json scripts for real ports tests from replit

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "test": "export $(cat .test.env | xargs) && USE_FAKE_PORTS='true' jest --group=-bq",
     "testWatch": "export $(cat .test.env | xargs) && USE_FAKE_PORTS='true' jest --watch",
     "testRealPorts": "export $(cat .test.env | xargs) && npm run dev:docker && jest --runInBand",
+    "testRealPortsReplit": "jest --runInBand",
     "testWatchRealPorts": "export $(cat .test.env | xargs) && npm run dev:docker && jest --watch --runInBand",
+    "testWatchRealPortsReplit": "jest --watch --runInBand",
     "prepare": "husky install"
   },
   "repository": {


### PR DESCRIPTION
This PR adds scripts that were forgotten from the original replit PR. These scripts make it easy to run real ports scripts from replit.