### PR TITLE
`createSleeperSeason` and `findSleeperSeasonBySleeperLeagueId`

### DIFF
--- a/__tests__/helpers/mocks/handlers.ts
+++ b/__tests__/helpers/mocks/handlers.ts
@@ -21,4 +21,7 @@ export const handlers = [
       })
     );
   }),
+  rest.get('https://api.sleeper.app/v1/league/DoesNotExist', (_request, response, context) => {
+    return response(context.status(404));
+  }),
 ];

--- a/__tests__/integration/season-controller.spec.ts
+++ b/__tests__/integration/season-controller.spec.ts
@@ -25,6 +25,7 @@ describe('season-controller', () => {
     expect(fetchSeasonResponse.data).toEqual({
       leagueId,
       id: seasonId,
+      sleeperLeagueId: '',
       year: new Date().getFullYear(),
     });
   });
@@ -39,6 +40,7 @@ describe('season-controller', () => {
     expect(fetchSeasonResponse.data).toEqual({
       leagueId,
       id: createSeasonResponse.data,
+      sleeperLeagueId: '',
       year: new Date().getFullYear(),
     });
   });

--- a/__tests__/integration/season-controller.spec.ts
+++ b/__tests__/integration/season-controller.spec.ts
@@ -1,4 +1,5 @@
-import axios from 'axios';
+import { SleeperSeason } from '@entities/season';
+import axios, { AxiosResponse } from 'axios';
 
 describe('season-controller', () => {
   const host = process.env['STATS_API_URL'];
@@ -35,7 +36,7 @@ describe('season-controller', () => {
     const createLeagueResponse = await axios.post(`${host}leagues`, { leagueName });
     const leagueId = createLeagueResponse.data;
     const createSeasonResponse = await axios.post(`${host}seasons`, { leagueId });
-    const fetchSeasonResponse = await axios.get(`${host}seasons/${leagueId}/${new Date().getFullYear()}`);
+    const fetchSeasonResponse = await axios.get(`${host}seasons/base/${leagueId}/${new Date().getFullYear()}`);
 
     expect(fetchSeasonResponse.data).toEqual({
       leagueId,
@@ -46,22 +47,36 @@ describe('season-controller', () => {
 
   describe('sleeper seasons', () => {
     let leagueId: number;
+    let createSleeperSeasonResponse: AxiosResponse;
+    let sleeperSeason: SleeperSeason;
 
     beforeAll(async () => {
       const leagueName = 'IntegrationTestLeagueForSleeperSeason';
       const createLeagueResponse = await axios.post(`${host}leagues`, { leagueName });
       leagueId = createLeagueResponse.data;
-    });
-
-    it('creating a sleeper season and fetching it by sleeper season id', async () => {
-      const createSleeperSeasonResponse = await axios.post(`${host}seasons/sleeper`, {
+      createSleeperSeasonResponse = await axios.post(`${host}seasons/sleeper`, {
         leagueId,
         sleeperLeagueId: sleeperLeagueIdForDynasty2023,
       });
+    });
 
+    it('fetching a sleeper season by sleeperLeagueId', async () => {
       const fetchSleeperSeasonResponse = await axios.get(
-        `${host}seasons/sleeper/external/${sleeperLeagueIdForDynasty2023}`
+        `${host}seasons/sleeper/external-id/${sleeperLeagueIdForDynasty2023}`
       );
+
+      sleeperSeason = fetchSleeperSeasonResponse.data;
+
+      expect(fetchSleeperSeasonResponse.data).toEqual({
+        leagueId,
+        id: createSleeperSeasonResponse.data,
+        sleeperLeagueId: sleeperLeagueIdForDynasty2023,
+        year: new Date().getFullYear(),
+      });
+    });
+
+    it('fetching a sleeper season by seasonId', async () => {
+      const fetchSleeperSeasonResponse = await axios.get(`${host}seasons/sleeper/${sleeperSeason.id}`);
 
       expect(fetchSleeperSeasonResponse.data).toEqual({
         leagueId,

--- a/__tests__/integration/season-controller.spec.ts
+++ b/__tests__/integration/season-controller.spec.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 describe('season-controller', () => {
   const host = process.env['STATS_API_URL'];
+  const sleeperLeagueIdForDynasty2023 = '985676679735504896';
 
   // TODO: this intermittently fails. likely because the tests aren't isolated well enough?
   it('creating a season', async () => {
@@ -40,6 +41,34 @@ describe('season-controller', () => {
       leagueId,
       id: createSeasonResponse.data,
       year: new Date().getFullYear(),
+    });
+  });
+
+  describe('sleeper seasons', () => {
+    let leagueId: number;
+
+    beforeAll(async () => {
+      const leagueName = 'IntegrationTestLeagueForSleeperSeason';
+      const createLeagueResponse = await axios.post(`${host}leagues`, { leagueName });
+      leagueId = createLeagueResponse.data;
+    });
+
+    it('creating a sleeper season and fetching it by sleeper season id', async () => {
+      const createSleeperSeasonResponse = await axios.post(`${host}seasons/sleeper`, {
+        leagueId,
+        sleeperLeagueId: sleeperLeagueIdForDynasty2023,
+      });
+
+      const fetchSleeperSeasonResponse = await axios.get(
+        `${host}seasons/sleeper/external/${sleeperLeagueIdForDynasty2023}`
+      );
+
+      expect(fetchSleeperSeasonResponse.data).toEqual({
+        leagueId,
+        id: createSleeperSeasonResponse.data,
+        sleeperLeagueId: sleeperLeagueIdForDynasty2023,
+        year: new Date().getFullYear(),
+      });
     });
   });
 });

--- a/__tests__/integration/season-controller.spec.ts
+++ b/__tests__/integration/season-controller.spec.ts
@@ -25,7 +25,6 @@ describe('season-controller', () => {
     expect(fetchSeasonResponse.data).toEqual({
       leagueId,
       id: seasonId,
-      sleeperLeagueId: '',
       year: new Date().getFullYear(),
     });
   });
@@ -40,7 +39,6 @@ describe('season-controller', () => {
     expect(fetchSeasonResponse.data).toEqual({
       leagueId,
       id: createSeasonResponse.data,
-      sleeperLeagueId: '',
       year: new Date().getFullYear(),
     });
   });

--- a/__tests__/unit/ports/stats-repository.test.ts
+++ b/__tests__/unit/ports/stats-repository.test.ts
@@ -235,30 +235,31 @@ describe('stats-repository', () => {
         });
       });
 
-      // describe('findSleeperSeasonBySleeperLeagueId', () => {
-      //   describe('when a valid sleeperLeagueId is given', () => {
-      //     describe('and the season exists', () => {
-      //       it('returns the season', async () => {
-      //         const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
-      //         const leagueId = await repo.createLeague(leagueName);
-      //         const sleeperSeasonId = await repo.createSleeperSeason(leagueId, sleeperLeagueId);
+      describe('findSleeperSeasonBySleeperLeagueId', () => {
+        describe('when a valid sleeperLeagueId is given', () => {
+          describe('and the season exists', () => {
+            it('returns the season', async () => {
+              const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
+              const leagueId = await repo.createLeague(leagueName);
+              const seasonId = await repo.createSeason(leagueId);
+              const sleeperSeasonId = await repo.createSleeperSeason(seasonId, sleeperLeagueId);
 
-      //         expect(await repo.findSleeperSeasonBySleeperLeagueId(sleeperLeagueId)).toEqual({
-      //           id: sleeperSeasonId,
-      //           leagueId: leagueId,
-      //           sleeperLeagueId: sleeperLeagueId,
-      //           year: new Date().getFullYear(),
-      //         });
-      //       });
-      //     });
+              expect(await repo.findSleeperSeasonBySleeperLeagueId(sleeperLeagueId)).toEqual({
+                id: sleeperSeasonId,
+                leagueId: leagueId,
+                sleeperLeagueId: sleeperLeagueId,
+                year: new Date().getFullYear(),
+              });
+            });
+          });
 
-      //     describe('and the season does not exist', () => {
-      //       it('throws an error', async () => {
-      //         await expect(repo.findSleeperSeasonBySleeperLeagueId('-1')).rejects.toThrow();
-      //       });
-      //     });
-      //   });
-      // });
+          describe('and the season does not exist', () => {
+            it('throws an error', async () => {
+              await expect(repo.findSleeperSeasonBySleeperLeagueId('-1')).rejects.toThrow();
+            });
+          });
+        });
+      });
     });
   });
 

--- a/__tests__/unit/ports/stats-repository.test.ts
+++ b/__tests__/unit/ports/stats-repository.test.ts
@@ -4,6 +4,7 @@ import { StatsRepository } from '@ports/stats/stats-repository';
 import { isNumber } from '@utilities/is-number';
 import { getPortsForTesting } from '../../helpers/ports-for-testing';
 import { Team } from '@entities/team';
+import { v4 as uuidv4 } from 'uuid';
 
 describe('stats-repository', () => {
   let repo: StatsRepository;
@@ -113,7 +114,7 @@ describe('stats-repository', () => {
 
       describe('when the given league id does not exist', () => {
         it('throws an exception', async () => {
-          await expect(repo.createSeason(69)).rejects.toThrow();
+          await expect(repo.createSeason(9_999_999)).rejects.toThrow();
         });
       });
 
@@ -178,6 +179,91 @@ describe('stats-repository', () => {
             const leagueId = await repo.createLeague(leagueName);
 
             await expect(repo.findSeasonByLeagueAndYear(leagueId, new Date().getFullYear())).rejects.toThrow();
+          });
+        });
+      });
+    });
+
+    describe('sleeper seasons', () => {
+      let sleeperLeagueId: string;
+      beforeEach(() => {
+        sleeperLeagueId = uuidv4();
+      });
+
+      describe('createSleeperSeason', () => {
+        describe('when a valid combination of leagueId and sleeperLeagueId is given', () => {
+          it('returns the season id', async () => {
+            const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
+            const leagueId = await repo.createLeague(leagueName);
+
+            expect(typeof (await repo.createSleeperSeason(leagueId, sleeperLeagueId))).toBe('number');
+          });
+
+          it('creates a sleeper season', async () => {
+            const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
+            const leagueId = await repo.createLeague(leagueName);
+            const sleeperSeasonId = await repo.createSleeperSeason(leagueId, sleeperLeagueId);
+
+            expect(await repo.findSleeperSeasonBySleeperLeagueId(sleeperLeagueId)).toEqual({
+              id: sleeperSeasonId,
+              leagueId: leagueId,
+              sleeperLeagueId: sleeperLeagueId,
+              year: new Date().getFullYear(),
+            });
+          });
+
+          it('increments season ids for successively created sleeper seasons', async () => {
+            const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
+            const leagueId = await repo.createLeague(leagueName);
+            const anotherLeagueId = await repo.createLeague(leagueName);
+            const anotherSleeperLeagueId = uuidv4();
+
+            const sleeperSeasonId = await repo.createSleeperSeason(leagueId, sleeperLeagueId);
+            const anotherSleeperSeasonId = await repo.createSleeperSeason(anotherLeagueId, anotherSleeperLeagueId);
+
+            expect(anotherSleeperSeasonId).toEqual(sleeperSeasonId + 1);
+          });
+        });
+
+        describe('when the given league id does not exist', () => {
+          it('throws an exception', async () => {
+            await expect(repo.createSleeperSeason(9_999_990, '1234567890')).rejects.toThrow();
+          });
+        });
+
+        describe('when the season already exists', () => {
+          it('throws an exception', async () => {
+            const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
+            const leagueId = await repo.createLeague(leagueName);
+
+            await repo.createSleeperSeason(leagueId, sleeperLeagueId);
+
+            await expect(repo.createSleeperSeason(leagueId, sleeperLeagueId)).rejects.toThrow();
+          });
+        });
+      });
+
+      describe('findSleeperSeasonBySleeperLeagueId', () => {
+        describe('when a valid sleeperLeagueId is given', () => {
+          describe('and the season exists', () => {
+            it('returns the season', async () => {
+              const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
+              const leagueId = await repo.createLeague(leagueName);
+              const sleeperSeasonId = await repo.createSleeperSeason(leagueId, sleeperLeagueId);
+
+              expect(await repo.findSleeperSeasonBySleeperLeagueId(sleeperLeagueId)).toEqual({
+                id: sleeperSeasonId,
+                leagueId: leagueId,
+                sleeperLeagueId: sleeperLeagueId,
+                year: new Date().getFullYear(),
+              });
+            });
+          });
+
+          describe('and the season does not exist', () => {
+            it('throws an error', async () => {
+              await expect(repo.findSleeperSeasonBySleeperLeagueId('-1')).rejects.toThrow();
+            });
           });
         });
       });

--- a/__tests__/unit/ports/stats-repository.test.ts
+++ b/__tests__/unit/ports/stats-repository.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-commented-out-tests */
 import { League } from '@entities/league';
 import { Season } from '@entities/season';
 import { StatsRepository } from '@ports/stats/stats-repository';
@@ -97,7 +98,6 @@ describe('stats-repository', () => {
           const season: Season = {
             id: seasonId,
             leagueId: leagueId,
-            sleeperLeagueId: '',
             year: new Date().getFullYear(),
           };
 
@@ -139,7 +139,6 @@ describe('stats-repository', () => {
             const season: Season = {
               id: seasonId,
               leagueId: leagueId,
-              sleeperLeagueId: '',
               year: new Date().getFullYear(),
             };
 
@@ -165,7 +164,6 @@ describe('stats-repository', () => {
             const season: Season = {
               id: seasonId,
               leagueId: leagueId,
-              sleeperLeagueId: '',
               year: new Date().getFullYear(),
             };
 
@@ -195,78 +193,68 @@ describe('stats-repository', () => {
           it('returns the season id', async () => {
             const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
             const leagueId = await repo.createLeague(leagueName);
+            const seasonId = await repo.createSeason(leagueId);
 
-            expect(typeof (await repo.createSleeperSeason(leagueId, sleeperLeagueId))).toBe('number');
+            expect(typeof (await repo.createSleeperSeason(seasonId, sleeperLeagueId))).toBe('number');
           });
 
           it('creates a sleeper season', async () => {
             const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
             const leagueId = await repo.createLeague(leagueName);
-            const sleeperSeasonId = await repo.createSleeperSeason(leagueId, sleeperLeagueId);
+            const seasonId = await repo.createSeason(leagueId);
+            await repo.createSleeperSeason(seasonId, sleeperLeagueId);
 
             expect(await repo.findSleeperSeasonBySleeperLeagueId(sleeperLeagueId)).toEqual({
-              id: sleeperSeasonId,
+              id: seasonId,
               leagueId: leagueId,
               sleeperLeagueId: sleeperLeagueId,
               year: new Date().getFullYear(),
             });
           });
-
-          it('increments season ids for successively created sleeper seasons', async () => {
-            const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
-            const leagueId = await repo.createLeague(leagueName);
-            const anotherLeagueId = await repo.createLeague(leagueName);
-            const anotherSleeperLeagueId = uuidv4();
-
-            const sleeperSeasonId = await repo.createSleeperSeason(leagueId, sleeperLeagueId);
-            const anotherSleeperSeasonId = await repo.createSleeperSeason(anotherLeagueId, anotherSleeperLeagueId);
-
-            expect(anotherSleeperSeasonId).toEqual(sleeperSeasonId + 1);
-          });
         });
 
-        describe('when the given league id does not exist', () => {
-          it('throws an exception', async () => {
-            await expect(repo.createSleeperSeason(9_999_990, '1234567890')).rejects.toThrow();
-          });
-        });
+        // describe('when the given league id does not exist', () => {
+        //   it('throws an exception', async () => {
+        //     await expect(repo.createSleeperSeason(9_999_990, '1234567890')).rejects.toThrow();
+        //   });
+        // });
 
-        describe('when the season already exists', () => {
-          it('throws an exception', async () => {
-            const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
-            const leagueId = await repo.createLeague(leagueName);
+        // describe('when the season already exists', () => {
+        //   it('throws an exception', async () => {
+        //     const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
+        //     const leagueId = await repo.createLeague(leagueName);
 
-            await repo.createSleeperSeason(leagueId, sleeperLeagueId);
+        //     await repo.createSleeperSeason(leagueId, sleeperLeagueId);
 
-            await expect(repo.createSleeperSeason(leagueId, sleeperLeagueId)).rejects.toThrow();
-          });
-        });
+        //     await expect(repo.createSleeperSeason(leagueId, sleeperLeagueId)).rejects.toThrow();
+        //   });
+        // });
       });
 
-      describe('findSleeperSeasonBySleeperLeagueId', () => {
-        describe('when a valid sleeperLeagueId is given', () => {
-          describe('and the season exists', () => {
-            it('returns the season', async () => {
-              const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
-              const leagueId = await repo.createLeague(leagueName);
-              const sleeperSeasonId = await repo.createSleeperSeason(leagueId, sleeperLeagueId);
+      // describe('findSleeperSeasonBySleeperLeagueId', () => {
+      //   describe('when a valid sleeperLeagueId is given', () => {
+      //     describe('and the season exists', () => {
+      //       it('returns the season', async () => {
+      //         const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
+      //         const leagueId = await repo.createLeague(leagueName);
+      //         const sleeperSeasonId = await repo.createSleeperSeason(leagueId, sleeperLeagueId);
 
-              expect(await repo.findSleeperSeasonBySleeperLeagueId(sleeperLeagueId)).toEqual({
-                id: sleeperSeasonId,
-                leagueId: leagueId,
-                sleeperLeagueId: sleeperLeagueId,
-                year: new Date().getFullYear(),
-              });
-            });
-          });
+      //         expect(await repo.findSleeperSeasonBySleeperLeagueId(sleeperLeagueId)).toEqual({
+      //           id: sleeperSeasonId,
+      //           leagueId: leagueId,
+      //           sleeperLeagueId: sleeperLeagueId,
+      //           year: new Date().getFullYear(),
+      //         });
+      //       });
+      //     });
 
-          describe('and the season does not exist', () => {
-            it('throws an error', async () => {
-              await expect(repo.findSleeperSeasonBySleeperLeagueId('-1')).rejects.toThrow();
-            });
-          });
-        });
-      });
+      //     describe('and the season does not exist', () => {
+      //       it('throws an error', async () => {
+      //         await expect(repo.findSleeperSeasonBySleeperLeagueId('-1')).rejects.toThrow();
+      //       });
+      //     });
+      //   });
+      // });
     });
   });
 

--- a/__tests__/unit/ports/stats-repository.test.ts
+++ b/__tests__/unit/ports/stats-repository.test.ts
@@ -213,22 +213,26 @@ describe('stats-repository', () => {
           });
         });
 
-        // describe('when the given league id does not exist', () => {
-        //   it('throws an exception', async () => {
-        //     await expect(repo.createSleeperSeason(9_999_990, '1234567890')).rejects.toThrow();
-        //   });
-        // });
+        // it is a business rule that the Season to SleeperSeason relationship is 1:1
+        describe('when the sleeper season already exists', () => {
+          it('throws an exception', async () => {
+            const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
+            const leagueId = await repo.createLeague(leagueName);
+            const seasonId = await repo.createSeason(leagueId);
+            const repeatedSleeperLeagueId = uuidv4();
 
-        // describe('when the season already exists', () => {
-        //   it('throws an exception', async () => {
-        //     const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
-        //     const leagueId = await repo.createLeague(leagueName);
+            await repo.createSleeperSeason(seasonId, repeatedSleeperLeagueId);
 
-        //     await repo.createSleeperSeason(leagueId, sleeperLeagueId);
+            await expect(repo.createSleeperSeason(seasonId, repeatedSleeperLeagueId)).rejects.toThrow();
+          });
+        });
 
-        //     await expect(repo.createSleeperSeason(leagueId, sleeperLeagueId)).rejects.toThrow();
-        //   });
-        // });
+        describe('when the Season does not exist', () => {
+          it('throws an exception', async () => {
+            const nonexistentSeasonId = 9_999_999;
+            await expect(repo.createSleeperSeason(nonexistentSeasonId, sleeperLeagueId)).rejects.toThrow();
+          });
+        });
       });
 
       // describe('findSleeperSeasonBySleeperLeagueId', () => {

--- a/__tests__/unit/ports/stats-repository.test.ts
+++ b/__tests__/unit/ports/stats-repository.test.ts
@@ -96,6 +96,7 @@ describe('stats-repository', () => {
           const season: Season = {
             id: seasonId,
             leagueId: leagueId,
+            sleeperLeagueId: '',
             year: new Date().getFullYear(),
           };
 
@@ -137,6 +138,7 @@ describe('stats-repository', () => {
             const season: Season = {
               id: seasonId,
               leagueId: leagueId,
+              sleeperLeagueId: '',
               year: new Date().getFullYear(),
             };
 
@@ -162,6 +164,7 @@ describe('stats-repository', () => {
             const season: Season = {
               id: seasonId,
               leagueId: leagueId,
+              sleeperLeagueId: '',
               year: new Date().getFullYear(),
             };
 

--- a/__tests__/unit/ports/stats-repository.test.ts
+++ b/__tests__/unit/ports/stats-repository.test.ts
@@ -260,6 +260,32 @@ describe('stats-repository', () => {
           });
         });
       });
+
+      describe('findSleeperSeasonBySeasonId', () => {
+        describe('when a valid seasonId is given', () => {
+          describe('and the season exists', () => {
+            it('returns the season', async () => {
+              const leagueName = 'testLeagueForSleeperSeasonRepositoryUnitTests';
+              const leagueId = await repo.createLeague(leagueName);
+              const seasonId = await repo.createSeason(leagueId);
+              const sleeperSeasonId = await repo.createSleeperSeason(seasonId, sleeperLeagueId);
+
+              expect(await repo.findSleeperSeasonBySeasonId(seasonId)).toEqual({
+                id: sleeperSeasonId,
+                leagueId: leagueId,
+                sleeperLeagueId: sleeperLeagueId,
+                year: new Date().getFullYear(),
+              });
+            });
+          });
+
+          describe('and the season does not exist', () => {
+            it('throws an error', async () => {
+              await expect(repo.findSleeperSeasonBySeasonId(-1)).rejects.toThrow();
+            });
+          });
+        });
+      });
     });
   });
 

--- a/__tests__/unit/services/stats/seasons/create-season.test.ts
+++ b/__tests__/unit/services/stats/seasons/create-season.test.ts
@@ -13,7 +13,6 @@ describe('createSeason service', () => {
       expect(season).toEqual({
         leagueId,
         id: seasonId,
-        sleeperLeagueId: '',
         year: new Date().getFullYear(),
       });
     });

--- a/__tests__/unit/services/stats/seasons/create-season.test.ts
+++ b/__tests__/unit/services/stats/seasons/create-season.test.ts
@@ -13,6 +13,7 @@ describe('createSeason service', () => {
       expect(season).toEqual({
         leagueId,
         id: seasonId,
+        sleeperLeagueId: '',
         year: new Date().getFullYear(),
       });
     });

--- a/__tests__/unit/services/stats/seasons/find-season-by-id.test.ts
+++ b/__tests__/unit/services/stats/seasons/find-season-by-id.test.ts
@@ -1,3 +1,4 @@
+import { Season } from '@entities/season';
 import { EntityDoesNotExistError } from '@services/errors';
 import { createLeague } from '@services/stats/leagues/create-league';
 import { createSeason } from '@services/stats/seasons/create-season';
@@ -10,9 +11,10 @@ describe('findSeasonById service', () => {
       const leagueId = await createLeague(leagueName);
       const seasonId = await createSeason(leagueId);
 
-      const someSeason = {
+      const someSeason: Season = {
         id: seasonId,
         leagueId,
+        sleeperLeagueId: '',
         year: new Date().getFullYear(),
       };
 

--- a/__tests__/unit/services/stats/seasons/find-season-by-id.test.ts
+++ b/__tests__/unit/services/stats/seasons/find-season-by-id.test.ts
@@ -14,7 +14,6 @@ describe('findSeasonById service', () => {
       const someSeason: Season = {
         id: seasonId,
         leagueId,
-        sleeperLeagueId: '',
         year: new Date().getFullYear(),
       };
 

--- a/__tests__/unit/services/stats/seasons/find-season-by-league-and-year.test.ts
+++ b/__tests__/unit/services/stats/seasons/find-season-by-league-and-year.test.ts
@@ -14,7 +14,6 @@ describe('findSeasonByLeagueAndYear service', () => {
       const someSeason: Season = {
         id: seasonId,
         leagueId,
-        sleeperLeagueId: '',
         year: new Date().getFullYear(),
       };
 

--- a/__tests__/unit/services/stats/seasons/find-season-by-league-and-year.test.ts
+++ b/__tests__/unit/services/stats/seasons/find-season-by-league-and-year.test.ts
@@ -1,3 +1,4 @@
+import { Season } from '@entities/season';
 import { EntityDoesNotExistError } from '@services/errors';
 import { createLeague } from '@services/stats/leagues/create-league';
 import { createSeason } from '@services/stats/seasons/create-season';
@@ -10,9 +11,10 @@ describe('findSeasonByLeagueAndYear service', () => {
       const leagueId = await createLeague(leagueName);
       const seasonId = await createSeason(leagueId);
 
-      const someSeason = {
+      const someSeason: Season = {
         id: seasonId,
         leagueId,
+        sleeperLeagueId: '',
         year: new Date().getFullYear(),
       };
 

--- a/__tests__/unit/services/stats/seasons/sleeperSeasons/create-sleeper-season.test.ts
+++ b/__tests__/unit/services/stats/seasons/sleeperSeasons/create-sleeper-season.test.ts
@@ -1,12 +1,12 @@
 import { EntityAlreadyExistsError, EntityDoesNotExistError } from '@services/errors';
 import { createLeague } from '@services/stats/leagues/create-league';
-import { createSeason } from '@services/stats/seasons/create-season';
 import { createSleeperSeason } from '@services/stats/seasons/sleeperSeasons/create-sleeper-season';
 import { SleeperSeason } from '@entities/season';
 import { findSleeperSeasonBySleeperLeagueId } from '@services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id';
 import { server } from '../../../../../helpers/mocks/server';
 import { getPortsForTesting } from '../../../../../helpers/ports-for-testing';
 import { StatsRepository } from '@ports/stats/stats-repository';
+import { findSeasonByLeagueAndYear } from '@services/stats/seasons/find-season-by-league-and-year';
 
 describe('createSleeperSeason service', () => {
   const mockedSleeperLeagueId = '1234';
@@ -23,16 +23,16 @@ describe('createSleeperSeason service', () => {
   });
   afterAll(() => server.close());
 
-  describe('when a unique combination of seasonId and sleeperLeagueId is given', () => {
+  describe('when a unique combination of leagueId and sleeperLeagueId is given', () => {
     it('creates a sleeperSeason', async () => {
       const someLeagueName = 'someLeagueNameUnique';
       const leagueId = await createLeague(someLeagueName);
-      const seasonId = await createSeason(leagueId);
-      await createSleeperSeason(seasonId, mockedSleeperLeagueId);
+      await createSleeperSeason(leagueId, mockedSleeperLeagueId);
+      const season = await findSeasonByLeagueAndYear(leagueId, new Date().getFullYear());
       const sleeperSeason: SleeperSeason = await findSleeperSeasonBySleeperLeagueId(mockedSleeperLeagueId);
       expect(sleeperSeason).toEqual({
         sleeperLeagueId: mockedSleeperLeagueId,
-        id: seasonId,
+        id: season.id,
         leagueId: leagueId,
         year: new Date().getFullYear(),
       });
@@ -40,14 +40,13 @@ describe('createSleeperSeason service', () => {
     });
   });
 
-  describe('when a non unique combination of seasonId and sleeperLeagueId is passed in', () => {
+  describe('when a non unique combination of leagueId and sleeperLeagueId is passed in', () => {
     it('throws an EntityAlreadyExistsError', async () => {
       const someLeagueName = 'someLeagueName';
       const leagueId = await createLeague(someLeagueName);
-      const seasonId = await createSeason(leagueId);
-      await createSleeperSeason(seasonId, mockedSleeperLeagueId);
+      await createSleeperSeason(leagueId, mockedSleeperLeagueId);
 
-      await expect(createSleeperSeason(seasonId, mockedSleeperLeagueId)).rejects.toEqual(
+      await expect(createSleeperSeason(leagueId, mockedSleeperLeagueId)).rejects.toEqual(
         new EntityAlreadyExistsError(`A sleeper season already exists for that SleeperLeagueId`)
       );
 
@@ -55,10 +54,10 @@ describe('createSleeperSeason service', () => {
     });
   });
 
-  describe('when a non existent season id is passed in', () => {
+  describe('when a non existent league id is passed in', () => {
     it('throws an exception', async () => {
       await expect(createSleeperSeason(9_999_999, mockedSleeperLeagueId)).rejects.toEqual(
-        new EntityDoesNotExistError(`No season found for season id 9999999`)
+        new EntityDoesNotExistError(`No league found for that ID`)
       );
     });
   });
@@ -67,9 +66,8 @@ describe('createSleeperSeason service', () => {
     it('throws an exception', async () => {
       const someLeagueName = 'someLeagueName';
       const leagueId = await createLeague(someLeagueName);
-      const seasonId = await createSeason(leagueId);
 
-      await expect(createSleeperSeason(seasonId, 'DoesNotExist')).rejects.toEqual(
+      await expect(createSleeperSeason(leagueId, 'DoesNotExist')).rejects.toEqual(
         new EntityDoesNotExistError(`No league found on Sleeper found for SleeperLeagueId DoesNotExist`)
       );
     });

--- a/__tests__/unit/services/stats/seasons/sleeperSeasons/create-sleeper-season.test.ts
+++ b/__tests__/unit/services/stats/seasons/sleeperSeasons/create-sleeper-season.test.ts
@@ -1,0 +1,47 @@
+import { EntityAlreadyExistsError, EntityDoesNotExistError } from '@services/errors';
+import { createLeague } from '@services/stats/leagues/create-league';
+import { createSeason } from '@services/stats/seasons/create-season';
+
+import { createSleeperSeason } from '@services/stats/seasons/sleeperSeasons/create-sleeper-season';
+import { SleeperSeason } from '@entities/season';
+import { findSleeperSeasonBySleeperLeagueId } from '@services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id';
+
+describe('createSleeperSeason service', () => {
+  const mockedSleeperLeagueId = '1234';
+
+  describe('when a unique combination of seasonId and sleeperLeagueId is given', () => {
+    it('creates a sleeperSeason', async () => {
+      const someLeagueName = 'someLeagueNameUnique';
+      const leagueId = await createLeague(someLeagueName);
+      const seasonId = await createSeason(leagueId);
+      const sleeperSeasonId = await createSleeperSeason(seasonId, mockedSleeperLeagueId);
+      const sleeperSeason: SleeperSeason = await findSleeperSeasonBySleeperLeagueId(mockedSleeperLeagueId);
+      expect(sleeperSeason).toEqual({
+        sleeperLeagueId: mockedSleeperLeagueId,
+        id: sleeperSeasonId,
+        seasonId,
+        year: new Date().getFullYear(),
+      });
+    });
+  });
+
+  describe('when a non unique combination of seasonId and sleeperLeagueId is passed in', () => {
+    it('throws an EntityAlreadyExistsError', async () => {
+      const someLeagueName = 'someLeagueName';
+      const leagueId = await createLeague(someLeagueName);
+      const seasonId = await createSeason(leagueId);
+      await createSleeperSeason(seasonId, mockedSleeperLeagueId);
+      await expect(createSleeperSeason(seasonId, mockedSleeperLeagueId)).rejects.toEqual(
+        new EntityAlreadyExistsError(`A sleeper season already exists for SleeperLeagueId ${mockedSleeperLeagueId}`)
+      );
+    });
+  });
+
+  describe('when a non existent season id is passed in', () => {
+    it('throws an exception', async () => {
+      await expect(createSleeperSeason(9_999_999, mockedSleeperLeagueId)).rejects.toEqual(
+        new EntityDoesNotExistError(`No league found for that ID`)
+      );
+    });
+  });
+});

--- a/__tests__/unit/services/stats/seasons/sleeperSeasons/create-sleeper-season.test.ts
+++ b/__tests__/unit/services/stats/seasons/sleeperSeasons/create-sleeper-season.test.ts
@@ -1,27 +1,42 @@
 import { EntityAlreadyExistsError, EntityDoesNotExistError } from '@services/errors';
 import { createLeague } from '@services/stats/leagues/create-league';
 import { createSeason } from '@services/stats/seasons/create-season';
-
 import { createSleeperSeason } from '@services/stats/seasons/sleeperSeasons/create-sleeper-season';
 import { SleeperSeason } from '@entities/season';
 import { findSleeperSeasonBySleeperLeagueId } from '@services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id';
+import { server } from '../../../../../helpers/mocks/server';
+import { getPortsForTesting } from '../../../../../helpers/ports-for-testing';
+import { StatsRepository } from '@ports/stats/stats-repository';
 
 describe('createSleeperSeason service', () => {
   const mockedSleeperLeagueId = '1234';
+  let ports;
+  let repo: StatsRepository;
+
+  beforeAll(() => {
+    server.listen();
+    ports = getPortsForTesting();
+    repo = ports.statsRepository;
+  });
+  afterEach(() => {
+    server.resetHandlers();
+  });
+  afterAll(() => server.close());
 
   describe('when a unique combination of seasonId and sleeperLeagueId is given', () => {
     it('creates a sleeperSeason', async () => {
       const someLeagueName = 'someLeagueNameUnique';
       const leagueId = await createLeague(someLeagueName);
       const seasonId = await createSeason(leagueId);
-      const sleeperSeasonId = await createSleeperSeason(seasonId, mockedSleeperLeagueId);
+      await createSleeperSeason(seasonId, mockedSleeperLeagueId);
       const sleeperSeason: SleeperSeason = await findSleeperSeasonBySleeperLeagueId(mockedSleeperLeagueId);
       expect(sleeperSeason).toEqual({
         sleeperLeagueId: mockedSleeperLeagueId,
-        id: sleeperSeasonId,
-        seasonId,
+        id: seasonId,
+        leagueId: leagueId,
         year: new Date().getFullYear(),
       });
+      await repo.deleteSleeperSeason(mockedSleeperLeagueId);
     });
   });
 
@@ -31,16 +46,31 @@ describe('createSleeperSeason service', () => {
       const leagueId = await createLeague(someLeagueName);
       const seasonId = await createSeason(leagueId);
       await createSleeperSeason(seasonId, mockedSleeperLeagueId);
+
       await expect(createSleeperSeason(seasonId, mockedSleeperLeagueId)).rejects.toEqual(
-        new EntityAlreadyExistsError(`A sleeper season already exists for SleeperLeagueId ${mockedSleeperLeagueId}`)
+        new EntityAlreadyExistsError(`A sleeper season already exists for that SleeperLeagueId`)
       );
+
+      await repo.deleteSleeperSeason(mockedSleeperLeagueId);
     });
   });
 
   describe('when a non existent season id is passed in', () => {
     it('throws an exception', async () => {
       await expect(createSleeperSeason(9_999_999, mockedSleeperLeagueId)).rejects.toEqual(
-        new EntityDoesNotExistError(`No league found for that ID`)
+        new EntityDoesNotExistError(`No season found for season id 9999999`)
+      );
+    });
+  });
+
+  describe('when a non existent sleeperLeagueId is passed in', () => {
+    it('throws an exception', async () => {
+      const someLeagueName = 'someLeagueName';
+      const leagueId = await createLeague(someLeagueName);
+      const seasonId = await createSeason(leagueId);
+
+      await expect(createSleeperSeason(seasonId, 'DoesNotExist')).rejects.toEqual(
+        new EntityDoesNotExistError(`No league found on Sleeper found for SleeperLeagueId DoesNotExist`)
       );
     });
   });

--- a/__tests__/unit/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-season-id.test.ts
+++ b/__tests__/unit/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-season-id.test.ts
@@ -1,0 +1,51 @@
+import { SleeperSeason } from '@entities/season';
+import { EntityDoesNotExistError } from '@services/errors';
+import { createLeague } from '@services/stats/leagues/create-league';
+import { createSleeperSeason } from '@services/stats/seasons/sleeperSeasons/create-sleeper-season';
+import { server } from '../../../../../helpers/mocks/server';
+import { StatsRepository } from '@ports/stats/stats-repository';
+import { getPortsForTesting } from '../../../../../helpers/ports-for-testing';
+import { findSeasonByLeagueAndYear } from '@services/stats/seasons/find-season-by-league-and-year';
+import { findSleeperSeasonBySeasonId } from '@services/stats/seasons/sleeperSeasons/find-sleeper-season-by-season-id';
+
+describe('findSleeperSeasonByseasonId service', () => {
+  const mockedSleeperLeagueId = '1234';
+  let ports;
+  let repo: StatsRepository;
+
+  beforeAll(() => {
+    server.listen();
+    ports = getPortsForTesting();
+    repo = ports.statsRepository;
+  });
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  describe('when a SleeperSeason exists with the given seasonId', () => {
+    it('returns it', async () => {
+      const leagueName = 'someLeagueName';
+      const leagueId = await createLeague(leagueName);
+      await createSleeperSeason(leagueId, mockedSleeperLeagueId);
+      const season = await findSeasonByLeagueAndYear(leagueId, new Date().getFullYear());
+      const someSleeperSeason: SleeperSeason = {
+        id: season.id,
+        leagueId,
+        sleeperLeagueId: mockedSleeperLeagueId,
+        year: new Date().getFullYear(),
+      };
+
+      const sleeperSeason = await findSleeperSeasonBySeasonId(season.id);
+
+      expect(someSleeperSeason).toEqual(sleeperSeason);
+      await repo.deleteSleeperSeason(mockedSleeperLeagueId);
+    });
+  });
+
+  describe('when a sleeper season does not exist with the given seasonId', () => {
+    it('returns throws an EntityDoesNotExistError', async () => {
+      await expect(findSleeperSeasonBySeasonId(9_999_999)).rejects.toEqual(
+        new EntityDoesNotExistError('No Sleeper season found for seasonId 9999999')
+      );
+    });
+  });
+});

--- a/__tests__/unit/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.test.ts
+++ b/__tests__/unit/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.test.ts
@@ -1,13 +1,13 @@
 import { SleeperSeason } from '@entities/season';
 import { EntityDoesNotExistError } from '@services/errors';
 import { createLeague } from '@services/stats/leagues/create-league';
-import { createSeason } from '@services/stats/seasons/create-season';
 import { findSeasonById } from '@services/stats/seasons/find-season-by-id';
 import { createSleeperSeason } from '@services/stats/seasons/sleeperSeasons/create-sleeper-season';
 import { findSleeperSeasonBySleeperLeagueId } from '@services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id';
 import { server } from '../../../../../helpers/mocks/server';
 import { StatsRepository } from '@ports/stats/stats-repository';
 import { getPortsForTesting } from '../../../../../helpers/ports-for-testing';
+import { findSeasonByLeagueAndYear } from '@services/stats/seasons/find-season-by-league-and-year';
 
 describe('findSleeperSeasonBySleeperLeagueId service', () => {
   const mockedSleeperLeagueId = '1234';
@@ -26,11 +26,10 @@ describe('findSleeperSeasonBySleeperLeagueId service', () => {
     it('returns it', async () => {
       const leagueName = 'someLeagueName';
       const leagueId = await createLeague(leagueName);
-      const seasonId = await createSeason(leagueId);
-      await createSleeperSeason(seasonId, mockedSleeperLeagueId);
-
+      await createSleeperSeason(leagueId, mockedSleeperLeagueId);
+      const season = await findSeasonByLeagueAndYear(leagueId, new Date().getFullYear());
       const someSleeperSeason: SleeperSeason = {
-        id: seasonId,
+        id: season.id,
         leagueId,
         sleeperLeagueId: mockedSleeperLeagueId,
         year: new Date().getFullYear(),

--- a/__tests__/unit/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.test.ts
+++ b/__tests__/unit/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.test.ts
@@ -1,13 +1,26 @@
-import { Season, SleeperSeason } from '@entities/season';
+import { SleeperSeason } from '@entities/season';
 import { EntityDoesNotExistError } from '@services/errors';
 import { createLeague } from '@services/stats/leagues/create-league';
 import { createSeason } from '@services/stats/seasons/create-season';
 import { findSeasonById } from '@services/stats/seasons/find-season-by-id';
 import { createSleeperSeason } from '@services/stats/seasons/sleeperSeasons/create-sleeper-season';
 import { findSleeperSeasonBySleeperLeagueId } from '@services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id';
+import { server } from '../../../../../helpers/mocks/server';
+import { StatsRepository } from '@ports/stats/stats-repository';
+import { getPortsForTesting } from '../../../../../helpers/ports-for-testing';
 
 describe('findSleeperSeasonBySleeperLeagueId service', () => {
   const mockedSleeperLeagueId = '1234';
+  let ports;
+  let repo: StatsRepository;
+
+  beforeAll(() => {
+    server.listen();
+    ports = getPortsForTesting();
+    repo = ports.statsRepository;
+  });
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
 
   describe('when a SleeperSeason exists with the given sleeperLeagueId', () => {
     it('returns it', async () => {
@@ -26,6 +39,7 @@ describe('findSleeperSeasonBySleeperLeagueId service', () => {
       const sleeperSeason = await findSleeperSeasonBySleeperLeagueId(mockedSleeperLeagueId);
 
       expect(someSleeperSeason).toEqual(sleeperSeason);
+      await repo.deleteSleeperSeason(mockedSleeperLeagueId);
     });
   });
 

--- a/__tests__/unit/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.test.ts
+++ b/__tests__/unit/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.test.ts
@@ -1,7 +1,6 @@
 import { SleeperSeason } from '@entities/season';
 import { EntityDoesNotExistError } from '@services/errors';
 import { createLeague } from '@services/stats/leagues/create-league';
-import { findSeasonById } from '@services/stats/seasons/find-season-by-id';
 import { createSleeperSeason } from '@services/stats/seasons/sleeperSeasons/create-sleeper-season';
 import { findSleeperSeasonBySleeperLeagueId } from '@services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id';
 import { server } from '../../../../../helpers/mocks/server';
@@ -42,10 +41,10 @@ describe('findSleeperSeasonBySleeperLeagueId service', () => {
     });
   });
 
-  describe('when a season does not exist with the given seasonId', () => {
+  describe('when a sleeper season does not exist with the given sleeperLeagueId', () => {
     it('returns throws an EntityDoesNotExistError', async () => {
-      await expect(findSeasonById(9_999_999)).rejects.toEqual(
-        new EntityDoesNotExistError('No season found for season id 9999999')
+      await expect(findSleeperSeasonBySleeperLeagueId('9999999')).rejects.toEqual(
+        new EntityDoesNotExistError('No Sleeper season found for SleeperLeagueId 9999999')
       );
     });
   });

--- a/__tests__/unit/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.test.ts
+++ b/__tests__/unit/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.test.ts
@@ -1,0 +1,39 @@
+import { Season, SleeperSeason } from '@entities/season';
+import { EntityDoesNotExistError } from '@services/errors';
+import { createLeague } from '@services/stats/leagues/create-league';
+import { createSeason } from '@services/stats/seasons/create-season';
+import { findSeasonById } from '@services/stats/seasons/find-season-by-id';
+import { createSleeperSeason } from '@services/stats/seasons/sleeperSeasons/create-sleeper-season';
+import { findSleeperSeasonBySleeperLeagueId } from '@services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id';
+
+describe('findSleeperSeasonBySleeperLeagueId service', () => {
+  const mockedSleeperLeagueId = '1234';
+
+  describe('when a SleeperSeason exists with the given sleeperLeagueId', () => {
+    it('returns it', async () => {
+      const leagueName = 'someLeagueName';
+      const leagueId = await createLeague(leagueName);
+      const seasonId = await createSeason(leagueId);
+      await createSleeperSeason(seasonId, mockedSleeperLeagueId);
+
+      const someSleeperSeason: SleeperSeason = {
+        id: seasonId,
+        leagueId,
+        sleeperLeagueId: mockedSleeperLeagueId,
+        year: new Date().getFullYear(),
+      };
+
+      const sleeperSeason = await findSleeperSeasonBySleeperLeagueId(mockedSleeperLeagueId);
+
+      expect(someSleeperSeason).toEqual(sleeperSeason);
+    });
+  });
+
+  describe('when a season does not exist with the given seasonId', () => {
+    it('returns throws an EntityDoesNotExistError', async () => {
+      await expect(findSeasonById(9_999_999)).rejects.toEqual(
+        new EntityDoesNotExistError('No season found for season id 9999999')
+      );
+    });
+  });
+});

--- a/prisma/migrations/20231014222120_season_id_sleeper_league_id_unique_pair/migration.sql
+++ b/prisma/migrations/20231014222120_season_id_sleeper_league_id_unique_pair/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[season_id,sleeper_league_id]` on the table `sleeperSeasons` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "sleeperSeasons_season_id_sleeper_league_id_key" ON "sleeperSeasons"("season_id", "sleeper_league_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,7 @@ model sleeperSeasons {
   seasonId        Int     @map("season_id")
   sleeperLeagueId String  @unique @map("sleeper_league_id") @db.VarChar(100)
   seasons         seasons @relation(fields: [seasonId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_season")
+  @@unique([seasonId, sleeperLeagueId])
 }
 
 model teams {

--- a/src/api/seasons/season-controller.ts
+++ b/src/api/seasons/season-controller.ts
@@ -1,4 +1,4 @@
-import { Season } from '../../entities/season';
+import { Season, SleeperSeason } from '../../entities/season';
 import { Body, Controller, Get, Middlewares, Path, Post, Route } from 'tsoa';
 import { findSeasonById } from '../../services/stats/seasons/find-season-by-id';
 import { findSeasonByLeagueAndYear } from '../../services/stats/seasons/find-season-by-league-and-year';
@@ -11,12 +11,27 @@ import { findSleeperSeasonBySeasonId } from '../../services/stats/seasons/sleepe
 @Route('seasons')
 @Middlewares(SeasonErrorHandlingMiddleware)
 export class SeasonsController extends Controller {
+  @Post('sleeper')
+  public async createSleeperSeason(@Body() body: { leagueId: number; sleeperLeagueId: string }): Promise<number> {
+    return await createSleeperSeason(body.leagueId, body.sleeperLeagueId);
+  }
+
+  @Get('sleeper/{seasonId}')
+  public async findSleeperSeasonBySeasonId(@Path() seasonId: number): Promise<SleeperSeason> {
+    return await findSleeperSeasonBySeasonId(seasonId);
+  }
+
+  @Get('sleeper/external-id/{sleeperLeagueId}')
+  public async findSleeperSeasonBySleeperLeagueId(@Path() sleeperLeagueId: string): Promise<SleeperSeason> {
+    return await findSleeperSeasonBySleeperLeagueId(sleeperLeagueId);
+  }
+
   @Get('{id}')
   public async findSeasonById(@Path() id: number): Promise<Season> {
     return await findSeasonById(id);
   }
 
-  @Get('{leagueId}/{year}')
+  @Get('base/{leagueId}/{year}')
   public async findSeasonByLeagueAndYear(@Path() leagueId: number, @Path() year: number): Promise<Season> {
     return await findSeasonByLeagueAndYear(leagueId, year);
   }
@@ -24,20 +39,5 @@ export class SeasonsController extends Controller {
   @Post('')
   public async createSeason(@Body() body: { leagueId: number }): Promise<number> {
     return await createSeason(body.leagueId);
-  }
-
-  @Post('sleeper')
-  public async createSleeperSeason(@Body() body: { leagueId: number; sleeperLeagueId: string }): Promise<number> {
-    return await createSleeperSeason(body.leagueId, body.sleeperLeagueId);
-  }
-
-  @Get('sleeper/external/{sleeperLeagueId}')
-  public async findSleeperSeasonBySleeperLeagueId(@Path() sleeperLeagueId: string): Promise<Season> {
-    return await findSleeperSeasonBySleeperLeagueId(sleeperLeagueId);
-  }
-
-  @Get('sleeper/{seasonId}')
-  public async findSleeperSeasonBySeasonId(@Path() seasonId: number): Promise<Season> {
-    return await findSleeperSeasonBySeasonId(seasonId);
   }
 }

--- a/src/api/seasons/season-controller.ts
+++ b/src/api/seasons/season-controller.ts
@@ -6,6 +6,7 @@ import { createSeason } from '../../services/stats/seasons/create-season';
 import { SeasonErrorHandlingMiddleware } from './season-error-handling-middleware';
 import { createSleeperSeason } from '../../services/stats/seasons/sleeperSeasons/create-sleeper-season';
 import { findSleeperSeasonBySleeperLeagueId } from '../../services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id';
+import { findSleeperSeasonBySeasonId } from '../../services/stats/seasons/sleeperSeasons/find-sleeper-season-by-season-id';
 
 @Route('seasons')
 @Middlewares(SeasonErrorHandlingMiddleware)
@@ -33,5 +34,10 @@ export class SeasonsController extends Controller {
   @Get('sleeper/external/{sleeperLeagueId}')
   public async findSleeperSeasonBySleeperLeagueId(@Path() sleeperLeagueId: string): Promise<Season> {
     return await findSleeperSeasonBySleeperLeagueId(sleeperLeagueId);
+  }
+
+  @Get('sleeper/{seasonId}')
+  public async findSleeperSeasonBySeasonId(@Path() seasonId: number): Promise<Season> {
+    return await findSleeperSeasonBySeasonId(seasonId);
   }
 }

--- a/src/api/seasons/season-controller.ts
+++ b/src/api/seasons/season-controller.ts
@@ -4,6 +4,7 @@ import { findSeasonById } from '../../services/stats/seasons/find-season-by-id';
 import { findSeasonByLeagueAndYear } from '../../services/stats/seasons/find-season-by-league-and-year';
 import { createSeason } from '../../services/stats/seasons/create-season';
 import { SeasonErrorHandlingMiddleware } from './season-error-handling-middleware';
+import { createSleeperSeason } from '@services/stats/seasons/sleeperSeasons/create-sleeper-season';
 
 @Route('seasons')
 @Middlewares(SeasonErrorHandlingMiddleware)
@@ -21,5 +22,10 @@ export class SeasonsController extends Controller {
   @Post('')
   public async createSeason(@Body() body: { leagueId: number }): Promise<number> {
     return await createSeason(body.leagueId);
+  }
+
+  @Post('sleeper/{leagueId}')
+  public async createSleeperSeason(@Path() leagueId: number, @Body() sleeperLeagueId: string): Promise<number> {
+    return await createSleeperSeason(leagueId, sleeperLeagueId);
   }
 }

--- a/src/api/seasons/season-controller.ts
+++ b/src/api/seasons/season-controller.ts
@@ -4,7 +4,8 @@ import { findSeasonById } from '../../services/stats/seasons/find-season-by-id';
 import { findSeasonByLeagueAndYear } from '../../services/stats/seasons/find-season-by-league-and-year';
 import { createSeason } from '../../services/stats/seasons/create-season';
 import { SeasonErrorHandlingMiddleware } from './season-error-handling-middleware';
-import { createSleeperSeason } from '@services/stats/seasons/sleeperSeasons/create-sleeper-season';
+import { createSleeperSeason } from '../../services/stats/seasons/sleeperSeasons/create-sleeper-season';
+import { findSleeperSeasonBySleeperLeagueId } from '../../services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id';
 
 @Route('seasons')
 @Middlewares(SeasonErrorHandlingMiddleware)
@@ -24,8 +25,13 @@ export class SeasonsController extends Controller {
     return await createSeason(body.leagueId);
   }
 
-  @Post('sleeper/{leagueId}')
-  public async createSleeperSeason(@Path() leagueId: number, @Body() sleeperLeagueId: string): Promise<number> {
-    return await createSleeperSeason(leagueId, sleeperLeagueId);
+  @Post('sleeper')
+  public async createSleeperSeason(@Body() body: { leagueId: number; sleeperLeagueId: string }): Promise<number> {
+    return await createSleeperSeason(body.leagueId, body.sleeperLeagueId);
+  }
+
+  @Get('sleeper/external/{sleeperLeagueId}')
+  public async findSleeperSeasonBySleeperLeagueId(@Path() sleeperLeagueId: string): Promise<Season> {
+    return await findSleeperSeasonBySleeperLeagueId(sleeperLeagueId);
   }
 }

--- a/src/entities/season.ts
+++ b/src/entities/season.ts
@@ -11,16 +11,26 @@ export class Season {
 }
 
 export class SleeperSeason extends Season {
-  seasonId: number;
-  sleeperSeasonId: string;
+  id: number;
+  sleeperLeagueId: string;
   leagueId: number;
   year: number;
 
-  constructor(seasonId: number, sleeperSeasonId: string, leagueId: number, year: number) {
-    super(seasonId, leagueId, year);
-    this.seasonId = seasonId;
-    this.sleeperSeasonId = sleeperSeasonId;
+  constructor(id: number, sleeperLeagueId: string, leagueId: number, year: number) {
+    super(id, leagueId, year);
+    this.id = id;
+    this.sleeperLeagueId = sleeperLeagueId;
     this.leagueId = leagueId;
     this.year = year;
+  }
+}
+
+export class SleeperSeasonEntityRelation {
+  seasonId: number;
+  sleeperLeagueId: string;
+
+  constructor(seasonId: number, sleeperLeagueId: string) {
+    this.seasonId = seasonId;
+    this.sleeperLeagueId = sleeperLeagueId;
   }
 }

--- a/src/entities/season.ts
+++ b/src/entities/season.ts
@@ -5,7 +5,8 @@ export class Season {
 
   constructor(id: number, leagueId: number, year: number) {
     this.id = id;
-    (this.leagueId = leagueId), (this.year = year);
+    this.leagueId = leagueId;
+    this.year = year;
   }
 }
 

--- a/src/entities/season.ts
+++ b/src/entities/season.ts
@@ -11,17 +11,11 @@ export class Season {
 }
 
 export class SleeperSeason extends Season {
-  id: number;
   sleeperLeagueId: string;
-  leagueId: number;
-  year: number;
 
   constructor(id: number, sleeperLeagueId: string, leagueId: number, year: number) {
     super(id, leagueId, year);
-    this.id = id;
     this.sleeperLeagueId = sleeperLeagueId;
-    this.leagueId = leagueId;
-    this.year = year;
   }
 }
 

--- a/src/ports/sleeper-client/http-sleeper-client.ts
+++ b/src/ports/sleeper-client/http-sleeper-client.ts
@@ -16,13 +16,8 @@ export class HttpSleeperClient implements SleeperClient {
   }
 
   async doesSleeperLeagueExistBySleeperLeagueId(sleeperLeagueId: string): Promise<boolean> {
-    try {
-      const response = await axios.get(`${this.sleeperApiUrl}/league/${sleeperLeagueId}`);
-      return !!response.data;
-    } catch (error) {
-      console.log(error);
-      throw error;
-    }
+    const response = await axios.get(`${this.sleeperApiUrl}/league/${sleeperLeagueId}`);
+    return !!response.data;
   }
 
   private convertSleeperLeagueDTOToSleeperLeague(sleeperLeagueDTO: SleeperLeagueDTO): SleeperLeague {

--- a/src/ports/sleeper-client/http-sleeper-client.ts
+++ b/src/ports/sleeper-client/http-sleeper-client.ts
@@ -15,6 +15,16 @@ export class HttpSleeperClient implements SleeperClient {
     }
   }
 
+  async doesSleeperLeagueExistBySleeperLeagueId(sleeperLeagueId: string): Promise<boolean> {
+    try {
+      const response = await axios.get(`${this.sleeperApiUrl}/league/${sleeperLeagueId}`);
+      return !!response.data;
+    } catch (error) {
+      console.log(error);
+      throw error;
+    }
+  }
+
   private convertSleeperLeagueDTOToSleeperLeague(sleeperLeagueDTO: SleeperLeagueDTO): SleeperLeague {
     return {
       leagueId: sleeperLeagueDTO.league_id,

--- a/src/ports/sleeper-client/sleeper-client.ts
+++ b/src/ports/sleeper-client/sleeper-client.ts
@@ -2,4 +2,5 @@ import { SleeperLeague } from '../../entities/sleeper/sleeper-league';
 
 export interface SleeperClient {
   getLeagueById(sleeperLeagueId: string): Promise<SleeperLeague>;
+  doesSleeperLeagueExistBySleeperLeagueId(sleeperLeagueId: string): Promise<boolean>;
 }

--- a/src/ports/stats/in-memory-stats-repository.ts
+++ b/src/ports/stats/in-memory-stats-repository.ts
@@ -103,8 +103,8 @@ export class InMemoryStatsRepository implements StatsRepository {
     throw new Error('Method not implemented.');
   }
 
-  createSleeperSeason(leagueId: number, sleeperLeagueId: string): Promise<number> {
-    console.log(leagueId, sleeperLeagueId);
+  createSleeperSeason(seasonId: number, sleeperLeagueId: string): Promise<number> {
+    console.log(seasonId, sleeperLeagueId);
     throw new Error('Method not implemented.');
   }
   findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<Season> {

--- a/src/ports/stats/in-memory-stats-repository.ts
+++ b/src/ports/stats/in-memory-stats-repository.ts
@@ -115,6 +115,10 @@ export class InMemoryStatsRepository implements StatsRepository {
     console.log(seasonId);
     throw new Error('Method not implemented.');
   }
+  doesSleeperSeasonExistBySleeperLeagueId(sleeperLeagueId: string): Promise<boolean> {
+    console.log(sleeperLeagueId);
+    throw new Error('Method not implemented.');
+  }
 
   saveSleeperLeague(sleeperLeague: SleeperLeague): Promise<void> {
     console.log(sleeperLeague);

--- a/src/ports/stats/in-memory-stats-repository.ts
+++ b/src/ports/stats/in-memory-stats-repository.ts
@@ -1,6 +1,6 @@
 import { League } from '@entities/league';
 import { Owner } from '@entities/owner';
-import { Season } from '@entities/season';
+import { Season, SleeperSeason } from '@entities/season';
 import { Team } from '@entities/team';
 import { StatsRepository } from './stats-repository';
 import { SleeperLeague } from '@entities/sleeper/sleeper-league';
@@ -107,11 +107,11 @@ export class InMemoryStatsRepository implements StatsRepository {
     console.log(seasonId, sleeperLeagueId);
     throw new Error('Method not implemented.');
   }
-  findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<Season> {
+  findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<SleeperSeason> {
     console.log(sleeperLeagueId);
     throw new Error('Method not implemented.');
   }
-  findSleeperSeasonBySeasonId(seasonId: number): Promise<Season> {
+  findSleeperSeasonBySeasonId(seasonId: number): Promise<SleeperSeason> {
     console.log(seasonId);
     throw new Error('Method not implemented.');
   }

--- a/src/ports/stats/in-memory-stats-repository.ts
+++ b/src/ports/stats/in-memory-stats-repository.ts
@@ -119,6 +119,10 @@ export class InMemoryStatsRepository implements StatsRepository {
     console.log(sleeperLeagueId);
     throw new Error('Method not implemented.');
   }
+  doesSleeperSeasonExistBySeasonId(seasonId: number): Promise<boolean> {
+    console.log(seasonId);
+    throw new Error('Method not implemented.');
+  }
 
   deleteSleeperSeason(sleeperLeagueId: string): Promise<void> {
     console.log(sleeperLeagueId);

--- a/src/ports/stats/in-memory-stats-repository.ts
+++ b/src/ports/stats/in-memory-stats-repository.ts
@@ -111,6 +111,10 @@ export class InMemoryStatsRepository implements StatsRepository {
     console.log(sleeperLeagueId);
     throw new Error('Method not implemented.');
   }
+  findSleeperSeasonBySeasonId(seasonId: number): Promise<Season> {
+    console.log(seasonId);
+    throw new Error('Method not implemented.');
+  }
 
   saveSleeperLeague(sleeperLeague: SleeperLeague): Promise<void> {
     console.log(sleeperLeague);

--- a/src/ports/stats/in-memory-stats-repository.ts
+++ b/src/ports/stats/in-memory-stats-repository.ts
@@ -120,6 +120,11 @@ export class InMemoryStatsRepository implements StatsRepository {
     throw new Error('Method not implemented.');
   }
 
+  deleteSleeperSeason(sleeperLeagueId: string): Promise<void> {
+    console.log(sleeperLeagueId);
+    throw new Error('Method not implemented.');
+  }
+
   saveSleeperLeague(sleeperLeague: SleeperLeague): Promise<void> {
     console.log(sleeperLeague);
     throw new Error('Method not implemented.');

--- a/src/ports/stats/in-memory-stats-repository.ts
+++ b/src/ports/stats/in-memory-stats-repository.ts
@@ -103,6 +103,15 @@ export class InMemoryStatsRepository implements StatsRepository {
     throw new Error('Method not implemented.');
   }
 
+  createSleeperSeason(leagueId: number, sleeperLeagueId: string): Promise<number> {
+    console.log(leagueId, sleeperLeagueId);
+    throw new Error('Method not implemented.');
+  }
+  findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<Season> {
+    console.log(sleeperLeagueId);
+    throw new Error('Method not implemented.');
+  }
+
   saveSleeperLeague(sleeperLeague: SleeperLeague): Promise<void> {
     console.log(sleeperLeague);
     throw new Error('Method not implemented.');

--- a/src/ports/stats/pg-stats-repository.ts
+++ b/src/ports/stats/pg-stats-repository.ts
@@ -5,6 +5,7 @@ import { Team } from '@entities/team';
 import prisma from '.';
 import { StatsRepository } from './stats-repository';
 import { SleeperLeague } from '@entities/sleeper/sleeper-league';
+import { sleeperSeasons } from '@prisma/client';
 
 export class PgStatsRepository implements StatsRepository {
   async createLeague(leagueName: string): Promise<number> {
@@ -171,6 +172,28 @@ export class PgStatsRepository implements StatsRepository {
       where: { sleeperLeagueId },
       include: { seasons: true },
     });
+
+    return {
+      id: result.seasonId,
+      sleeperLeagueId: result.sleeperLeagueId,
+      leagueId: result.seasons.leagueId,
+      year: result.seasons.year,
+    };
+  }
+
+  async findSleeperSeasonBySeasonId(seasonId: number): Promise<SleeperSeason> {
+    const result:
+      | (sleeperSeasons & {
+          seasons: Season;
+        })
+      | null = await prisma.sleeperSeasons.findFirst({
+      where: { seasonId },
+      include: { seasons: true },
+    });
+
+    if (!result) {
+      throw new Error(`No SleeperSeason found for seasonId ${seasonId}`);
+    }
 
     return {
       id: result.seasonId,

--- a/src/ports/stats/pg-stats-repository.ts
+++ b/src/ports/stats/pg-stats-repository.ts
@@ -211,6 +211,12 @@ export class PgStatsRepository implements StatsRepository {
     return result === 1 ? true : false;
   }
 
+  async deleteSleeperSeason(sleeperLeagueId: string): Promise<void> {
+    await prisma.sleeperSeasons.delete({
+      where: { sleeperLeagueId },
+    });
+  }
+
   async saveSleeperLeague(sleeperLeague: SleeperLeague): Promise<void> {
     console.log(sleeperLeague);
     // TODO: save SleeperLeagueDTO to a new schema for it

--- a/src/ports/stats/pg-stats-repository.ts
+++ b/src/ports/stats/pg-stats-repository.ts
@@ -152,6 +152,30 @@ export class PgStatsRepository implements StatsRepository {
     return !!result;
   }
 
+  async createSleeperSeason(leagueId: number, sleeperLeagueId: string): Promise<number> {
+    const result = await prisma.seasons.create({
+      data: {
+        leagueId,
+        sleeperLeagueId,
+        year: new Date().getFullYear(),
+      },
+      select: { id: true },
+    });
+
+    return result.id;
+  }
+
+  async findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<Season> {
+    // Prisma does not support nullable unique columns yet. I would rather do findUniqueOrThrow here.
+    // can't do that because if I set sleeperLeagueId to @unique in the schema, it can't be nullable. thus defeating the purpose
+    // of keeping my season entity independent from any single platform
+    const result: Season = await prisma.seasons.findFirstOrThrow({
+      where: { sleeperLeagueId },
+    });
+
+    return result;
+  }
+
   async saveSleeperLeague(sleeperLeague: SleeperLeague): Promise<void> {
     console.log(sleeperLeague);
     // TODO: save sleeperLeague to a new schema for it

--- a/src/ports/stats/pg-stats-repository.ts
+++ b/src/ports/stats/pg-stats-repository.ts
@@ -203,6 +203,14 @@ export class PgStatsRepository implements StatsRepository {
     };
   }
 
+  async doesSleeperSeasonExistBySleeperLeagueId(sleeperLeagueId: string): Promise<boolean> {
+    const result: number = await prisma.sleeperSeasons.count({
+      where: { sleeperLeagueId },
+    });
+
+    return result === 1 ? true : false;
+  }
+
   async saveSleeperLeague(sleeperLeague: SleeperLeague): Promise<void> {
     console.log(sleeperLeague);
     // TODO: save SleeperLeagueDTO to a new schema for it

--- a/src/ports/stats/pg-stats-repository.ts
+++ b/src/ports/stats/pg-stats-repository.ts
@@ -211,6 +211,14 @@ export class PgStatsRepository implements StatsRepository {
     return result === 1 ? true : false;
   }
 
+  async doesSleeperSeasonExistBySeasonId(seasonId: number): Promise<boolean> {
+    const result: number = await prisma.sleeperSeasons.count({
+      where: { seasonId },
+    });
+
+    return result === 1 ? true : false;
+  }
+
   async deleteSleeperSeason(sleeperLeagueId: string): Promise<void> {
     await prisma.sleeperSeasons.delete({
       where: { sleeperLeagueId },

--- a/src/ports/stats/pg-stats-repository.ts
+++ b/src/ports/stats/pg-stats-repository.ts
@@ -5,7 +5,6 @@ import { Team } from '@entities/team';
 import prisma from '.';
 import { StatsRepository } from './stats-repository';
 import { SleeperLeague } from '@entities/sleeper/sleeper-league';
-import { sleeperSeasons } from '@prisma/client';
 
 export class PgStatsRepository implements StatsRepository {
   async createLeague(leagueName: string): Promise<number> {
@@ -182,11 +181,7 @@ export class PgStatsRepository implements StatsRepository {
   }
 
   async findSleeperSeasonBySeasonId(seasonId: number): Promise<SleeperSeason> {
-    const result:
-      | (sleeperSeasons & {
-          seasons: Season;
-        })
-      | null = await prisma.sleeperSeasons.findFirst({
+    const result = await prisma.sleeperSeasons.findFirst({
       where: { seasonId },
       include: { seasons: true },
     });

--- a/src/ports/stats/pg-stats-repository.ts
+++ b/src/ports/stats/pg-stats-repository.ts
@@ -39,6 +39,7 @@ export class PgStatsRepository implements StatsRepository {
     const result = await prisma.seasons.create({
       data: {
         leagueId,
+        sleeperLeagueId: '',
         year: new Date().getFullYear(),
       },
       select: { id: true },

--- a/src/ports/stats/pg-stats-repository.ts
+++ b/src/ports/stats/pg-stats-repository.ts
@@ -151,7 +151,6 @@ export class PgStatsRepository implements StatsRepository {
     return !!result;
   }
 
-  // TODO: ensure there can't be more than one SleeperSeason per Season
   async createSleeperSeason(seasonId: number, sleeperLeagueId: string): Promise<number> {
     // TODO: create the new season in the service level above this. use that seasonId and pass into here
     const result = await prisma.sleeperSeasons.create({
@@ -162,15 +161,6 @@ export class PgStatsRepository implements StatsRepository {
       include: {
         seasons: true,
       },
-      // select: {
-      //   seasonId: true,
-      //   seasons: {
-      //     select: {
-      //       leagueId: true,
-      //       year: true,
-      //     },
-      //    }
-      //   },
     });
 
     return result.seasonId;

--- a/src/ports/stats/pg-stats-repository.ts
+++ b/src/ports/stats/pg-stats-repository.ts
@@ -159,7 +159,18 @@ export class PgStatsRepository implements StatsRepository {
         seasonId,
         sleeperLeagueId,
       },
-      select: { seasonId: true },
+      include: {
+        seasons: true,
+      },
+      // select: {
+      //   seasonId: true,
+      //   seasons: {
+      //     select: {
+      //       leagueId: true,
+      //       year: true,
+      //     },
+      //    }
+      //   },
     });
 
     return result.seasonId;
@@ -172,6 +183,7 @@ export class PgStatsRepository implements StatsRepository {
       include: { seasons: true },
     });
 
+    // TODO: look into massaging the type safety here before moving on
     return result as unknown as SleeperSeason;
   }
 

--- a/src/ports/stats/pg-stats-repository.ts
+++ b/src/ports/stats/pg-stats-repository.ts
@@ -1,6 +1,6 @@
 import { League } from '@entities/league';
 import { Owner } from '@entities/owner';
-import { Season, SleeperSeason } from '@entities/season';
+import { Season, SleeperSeason, SleeperSeasonEntityRelation } from '@entities/season';
 import { Team } from '@entities/team';
 import prisma from '.';
 import { StatsRepository } from './stats-repository';
@@ -176,19 +176,22 @@ export class PgStatsRepository implements StatsRepository {
     return result.seasonId;
   }
 
-  // TODO: what is the correct way to query this relation? I want the entire object, including SleeperSeasonId
   async findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<SleeperSeason> {
-    const result = await prisma.sleeperSeasons.findUniqueOrThrow({
+    const result: { seasons: Season } & SleeperSeasonEntityRelation = await prisma.sleeperSeasons.findUniqueOrThrow({
       where: { sleeperLeagueId },
       include: { seasons: true },
     });
 
-    // TODO: look into massaging the type safety here before moving on
-    return result as unknown as SleeperSeason;
+    return {
+      id: result.seasonId,
+      sleeperLeagueId: result.sleeperLeagueId,
+      leagueId: result.seasons.leagueId,
+      year: result.seasons.year,
+    };
   }
 
   async saveSleeperLeague(sleeperLeague: SleeperLeague): Promise<void> {
     console.log(sleeperLeague);
-    // TODO: save sleeperLeague to a new schema for it
+    // TODO: save SleeperLeagueDTO to a new schema for it
   }
 }

--- a/src/ports/stats/stats-repository.ts
+++ b/src/ports/stats/stats-repository.ts
@@ -28,6 +28,9 @@ export interface StatsRepository {
   findSleeperSeasonBySeasonId(seasonId: number): Promise<SleeperSeason>;
   doesSleeperSeasonExistBySleeperLeagueId(sleeperLeagueId: string): Promise<boolean>;
 
+  // this is a utility function for tests
+  deleteSleeperSeason(sleeperLeagueId: string): Promise<void>;
+
   // believe this was intended to be for storing DTOs
   // it is not currently (4.24.23) related to the particular flavor of Season object that contains a sleeperId
   saveSleeperLeague(sleeperLeague: SleeperLeague): Promise<void>;

--- a/src/ports/stats/stats-repository.ts
+++ b/src/ports/stats/stats-repository.ts
@@ -1,6 +1,6 @@
 import { League } from '@entities/league';
 import { Owner } from '@entities/owner';
-import { Season } from '@entities/season';
+import { Season, SleeperSeason } from '@entities/season';
 import { SleeperLeague } from '@entities/sleeper/sleeper-league';
 import { Team } from '@entities/team';
 
@@ -24,8 +24,8 @@ export interface StatsRepository {
   doesTeamExistById(teamId: number): Promise<boolean>;
 
   createSleeperSeason(seasonId: number, sleeperLeagueId: string): Promise<number>;
-  findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<Season>;
-  findSleeperSeasonBySeasonId(seasonId: number): Promise<Season>;
+  findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<SleeperSeason>;
+  findSleeperSeasonBySeasonId(seasonId: number): Promise<SleeperSeason>;
   doesSleeperSeasonExistBySleeperLeagueId(sleeperLeagueId: string): Promise<boolean>;
 
   // believe this was intended to be for storing DTOs

--- a/src/ports/stats/stats-repository.ts
+++ b/src/ports/stats/stats-repository.ts
@@ -23,5 +23,10 @@ export interface StatsRepository {
   doesTeamExist(seasonId: number, ownerId: number): Promise<boolean>;
   doesTeamExistById(teamId: number): Promise<boolean>;
 
+  createSleeperSeason(leagueId: number, sleeperLeagueId: string): Promise<number>;
+  findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<Season>;
+
+  // believe this was intended to be for storing DTOs
+  // it is not currently (4.24.23) related to the particular flavor of Season object that contains a sleeperId
   saveSleeperLeague(sleeperLeague: SleeperLeague): Promise<void>;
 }

--- a/src/ports/stats/stats-repository.ts
+++ b/src/ports/stats/stats-repository.ts
@@ -26,6 +26,7 @@ export interface StatsRepository {
   createSleeperSeason(seasonId: number, sleeperLeagueId: string): Promise<number>;
   findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<Season>;
   findSleeperSeasonBySeasonId(seasonId: number): Promise<Season>;
+  doesSleeperSeasonExistBySleeperLeagueId(sleeperLeagueId: string): Promise<boolean>;
 
   // believe this was intended to be for storing DTOs
   // it is not currently (4.24.23) related to the particular flavor of Season object that contains a sleeperId

--- a/src/ports/stats/stats-repository.ts
+++ b/src/ports/stats/stats-repository.ts
@@ -25,6 +25,7 @@ export interface StatsRepository {
 
   createSleeperSeason(seasonId: number, sleeperLeagueId: string): Promise<number>;
   findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<Season>;
+  findSleeperSeasonBySeasonId(seasonId: number): Promise<Season>;
 
   // believe this was intended to be for storing DTOs
   // it is not currently (4.24.23) related to the particular flavor of Season object that contains a sleeperId

--- a/src/ports/stats/stats-repository.ts
+++ b/src/ports/stats/stats-repository.ts
@@ -23,7 +23,7 @@ export interface StatsRepository {
   doesTeamExist(seasonId: number, ownerId: number): Promise<boolean>;
   doesTeamExistById(teamId: number): Promise<boolean>;
 
-  createSleeperSeason(leagueId: number, sleeperLeagueId: string): Promise<number>;
+  createSleeperSeason(seasonId: number, sleeperLeagueId: string): Promise<number>;
   findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<Season>;
 
   // believe this was intended to be for storing DTOs

--- a/src/ports/stats/stats-repository.ts
+++ b/src/ports/stats/stats-repository.ts
@@ -27,6 +27,7 @@ export interface StatsRepository {
   findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<SleeperSeason>;
   findSleeperSeasonBySeasonId(seasonId: number): Promise<SleeperSeason>;
   doesSleeperSeasonExistBySleeperLeagueId(sleeperLeagueId: string): Promise<boolean>;
+  doesSleeperSeasonExistBySeasonId(seasonId: number): Promise<boolean>;
 
   // this is a utility function for tests
   deleteSleeperSeason(sleeperLeagueId: string): Promise<void>;

--- a/src/services/stats/seasons/seasons-validators.ts
+++ b/src/services/stats/seasons/seasons-validators.ts
@@ -27,8 +27,9 @@ export async function validateSeasonExistsByLeagueId(leagueId: number): Promise<
 
 export async function validateSleeperLeagueExists(sleeperLeagueId: string): Promise<void> {
   const ports = await getPorts();
-  const doesSleeperLeagueExist = await ports.sleeperClient.doesSleeperLeagueExistBySleeperLeagueId(sleeperLeagueId);
-  if (!doesSleeperLeagueExist) {
+  try {
+    await ports.sleeperClient.doesSleeperLeagueExistBySleeperLeagueId(sleeperLeagueId);
+  } catch {
     throw new EntityDoesNotExistError(`No league found on Sleeper found for SleeperLeagueId ${sleeperLeagueId}`);
   }
 }
@@ -46,6 +47,6 @@ export async function validateSleeperSeasonDoesNotAlreadyExist(sleeperLeagueId: 
   const ports = await getPorts();
   const doesSleeperSeasonExist = await ports.statsRepository.doesSleeperSeasonExistBySleeperLeagueId(sleeperLeagueId);
   if (doesSleeperSeasonExist) {
-    throw new EntityAlreadyExistsError(`A sleeper season already exists for SleeperLeagueId ${sleeperLeagueId}`);
+    throw new EntityAlreadyExistsError(`A sleeper season already exists for that SleeperLeagueId`);
   }
 }

--- a/src/services/stats/seasons/seasons-validators.ts
+++ b/src/services/stats/seasons/seasons-validators.ts
@@ -43,6 +43,15 @@ export async function validateSleeperSeasonExistsBySleeperLeagueId(sleeperLeague
   }
 }
 
+export async function validateSleeperSeasonExistsBySeasonId(seasonId: number): Promise<void> {
+  const ports = await getPorts();
+  const doesSleeperSeasonExist = await ports.statsRepository.doesSleeperSeasonExistBySeasonId(seasonId);
+
+  if (!doesSleeperSeasonExist) {
+    throw new EntityDoesNotExistError(`No Sleeper season found for seasonId ${seasonId}`);
+  }
+}
+
 export async function validateSleeperSeasonDoesNotAlreadyExist(sleeperLeagueId: string): Promise<void> {
   const ports = await getPorts();
   const doesSleeperSeasonExist = await ports.statsRepository.doesSleeperSeasonExistBySleeperLeagueId(sleeperLeagueId);

--- a/src/services/stats/seasons/seasons-validators.ts
+++ b/src/services/stats/seasons/seasons-validators.ts
@@ -24,3 +24,19 @@ export async function validateSeasonExistsByLeagueId(leagueId: number): Promise<
     throw new EntityDoesNotExistError(`No season found for league id ${leagueId}`);
   }
 }
+
+export async function validateSleeperLeagueExists(sleeperLeagueId: string): Promise<void> {
+  const ports = await getPorts();
+  const doesSleeperLeagueExist = await ports.sleeperClient.doesSleeperLeagueExistBySleeperLeagueId(sleeperLeagueId);
+  if (!doesSleeperLeagueExist) {
+    throw new EntityDoesNotExistError(`No league found on Sleeper found for SleeperLeagueId ${sleeperLeagueId}`);
+  }
+}
+
+export async function validateSleeperSeasonDoesNotAlreadyExist(sleeperLeagueId: string): Promise<void> {
+  const ports = await getPorts();
+  const doesSleeperSeasonExist = await ports.statsRepository.doesSleeperSeasonExistBySleeperLeagueId(sleeperLeagueId);
+  if (doesSleeperSeasonExist) {
+    throw new EntityAlreadyExistsError(`A sleeper season already exists for SleeperLeagueId ${sleeperLeagueId}`);
+  }
+}

--- a/src/services/stats/seasons/seasons-validators.ts
+++ b/src/services/stats/seasons/seasons-validators.ts
@@ -33,6 +33,15 @@ export async function validateSleeperLeagueExists(sleeperLeagueId: string): Prom
   }
 }
 
+export async function validateSleeperSeasonExistsBySleeperLeagueId(sleeperLeagueId: string): Promise<void> {
+  const ports = await getPorts();
+  const doesSleeperSeasonExist = await ports.statsRepository.doesSleeperSeasonExistBySleeperLeagueId(sleeperLeagueId);
+
+  if (!doesSleeperSeasonExist) {
+    throw new EntityDoesNotExistError(`No Sleeper season found for SleeperLeagueId ${sleeperLeagueId}`);
+  }
+}
+
 export async function validateSleeperSeasonDoesNotAlreadyExist(sleeperLeagueId: string): Promise<void> {
   const ports = await getPorts();
   const doesSleeperSeasonExist = await ports.statsRepository.doesSleeperSeasonExistBySleeperLeagueId(sleeperLeagueId);

--- a/src/services/stats/seasons/sleeperSeasons/create-sleeper-season.ts
+++ b/src/services/stats/seasons/sleeperSeasons/create-sleeper-season.ts
@@ -1,0 +1,14 @@
+import { getPorts } from '../../../../ports/get-ports';
+import {
+  validateSleeperLeagueExists,
+  validateSeasonExistsBySeasonId,
+  validateSleeperSeasonDoesNotAlreadyExist,
+} from '../seasons-validators';
+
+export async function createSleeperSeason(seasonId: number, sleeperLeagueId: string): Promise<number> {
+  const ports = await getPorts();
+  await validateSeasonExistsBySeasonId(seasonId);
+  await validateSleeperLeagueExists(sleeperLeagueId);
+  await validateSleeperSeasonDoesNotAlreadyExist(sleeperLeagueId);
+  return await ports.statsRepository.createSleeperSeason(seasonId, sleeperLeagueId);
+}

--- a/src/services/stats/seasons/sleeperSeasons/create-sleeper-season.ts
+++ b/src/services/stats/seasons/sleeperSeasons/create-sleeper-season.ts
@@ -1,14 +1,13 @@
+import { validateLeagueExists } from '@services/stats/leagues/leagues-validators';
 import { getPorts } from '../../../../ports/get-ports';
-import {
-  validateSleeperLeagueExists,
-  validateSeasonExistsBySeasonId,
-  validateSleeperSeasonDoesNotAlreadyExist,
-} from '../seasons-validators';
+import { createSeason } from '../create-season';
+import { validateSleeperLeagueExists, validateSleeperSeasonDoesNotAlreadyExist } from '../seasons-validators';
 
-export async function createSleeperSeason(seasonId: number, sleeperLeagueId: string): Promise<number> {
+export async function createSleeperSeason(leagueId: number, sleeperLeagueId: string): Promise<number> {
   const ports = await getPorts();
-  await validateSeasonExistsBySeasonId(seasonId);
+  await validateLeagueExists(leagueId);
   await validateSleeperLeagueExists(sleeperLeagueId);
   await validateSleeperSeasonDoesNotAlreadyExist(sleeperLeagueId);
+  const seasonId = await createSeason(leagueId);
   return await ports.statsRepository.createSleeperSeason(seasonId, sleeperLeagueId);
 }

--- a/src/services/stats/seasons/sleeperSeasons/create-sleeper-season.ts
+++ b/src/services/stats/seasons/sleeperSeasons/create-sleeper-season.ts
@@ -1,4 +1,4 @@
-import { validateLeagueExists } from '@services/stats/leagues/leagues-validators';
+import { validateLeagueExists } from '../../../../services/stats/leagues/leagues-validators';
 import { getPorts } from '../../../../ports/get-ports';
 import { createSeason } from '../create-season';
 import { validateSleeperLeagueExists, validateSleeperSeasonDoesNotAlreadyExist } from '../seasons-validators';

--- a/src/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-season-id.ts
+++ b/src/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-season-id.ts
@@ -1,0 +1,9 @@
+import { SleeperSeason } from '../../../../entities/season';
+import { getPorts } from '../../../../ports/get-ports';
+import { validateSleeperSeasonExistsBySeasonId } from '../seasons-validators';
+
+export async function findSleeperSeasonBySeasonId(seasonId: number): Promise<SleeperSeason> {
+  const ports = await getPorts();
+  await validateSleeperSeasonExistsBySeasonId(seasonId);
+  return await ports.statsRepository.findSleeperSeasonBySeasonId(seasonId);
+}

--- a/src/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.ts
+++ b/src/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.ts
@@ -1,5 +1,5 @@
-import { SleeperSeason } from '@entities/season';
-import { getPorts } from '@ports/get-ports';
+import { SleeperSeason } from '../../../../entities/season';
+import { getPorts } from '../../../../ports/get-ports';
 import { validateSleeperSeasonExistsBySleeperLeagueId } from '../seasons-validators';
 
 export async function findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<SleeperSeason> {

--- a/src/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.ts
+++ b/src/services/stats/seasons/sleeperSeasons/find-sleeper-season-by-sleeper-league-id.ts
@@ -1,0 +1,9 @@
+import { SleeperSeason } from '@entities/season';
+import { getPorts } from '@ports/get-ports';
+import { validateSleeperSeasonExistsBySleeperLeagueId } from '../seasons-validators';
+
+export async function findSleeperSeasonBySleeperLeagueId(sleeperLeagueId: string): Promise<SleeperSeason> {
+  const ports = await getPorts();
+  await validateSleeperSeasonExistsBySleeperLeagueId(sleeperLeagueId);
+  return await ports.statsRepository.findSleeperSeasonBySleeperLeagueId(sleeperLeagueId);
+}

--- a/swagger.json
+++ b/swagger.json
@@ -40,6 +40,33 @@
 				"type": "object",
 				"additionalProperties": false
 			},
+			"SleeperSeason": {
+				"properties": {
+					"id": {
+						"type": "number",
+						"format": "double"
+					},
+					"leagueId": {
+						"type": "number",
+						"format": "double"
+					},
+					"year": {
+						"type": "number",
+						"format": "double"
+					},
+					"sleeperLeagueId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"id",
+					"leagueId",
+					"year",
+					"sleeperLeagueId"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
 			"Season": {
 				"properties": {
 					"id": {
@@ -328,6 +355,106 @@
 				}
 			}
 		},
+		"/seasons/sleeper": {
+			"post": {
+				"operationId": "CreateSleeperSeason",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "number",
+									"format": "double"
+								}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"properties": {
+									"sleeperLeagueId": {
+										"type": "string"
+									},
+									"leagueId": {
+										"type": "number",
+										"format": "double"
+									}
+								},
+								"required": [
+									"sleeperLeagueId",
+									"leagueId"
+								],
+								"type": "object"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/seasons/sleeper/{seasonId}": {
+			"get": {
+				"operationId": "FindSleeperSeasonBySeasonId",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/SleeperSeason"
+								}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "seasonId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
+			}
+		},
+		"/seasons/sleeper/external-id/{sleeperLeagueId}": {
+			"get": {
+				"operationId": "FindSleeperSeasonBySleeperLeagueId",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/SleeperSeason"
+								}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "sleeperLeagueId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
 		"/seasons/{id}": {
 			"get": {
 				"operationId": "FindSeasonById",
@@ -357,7 +484,7 @@
 				]
 			}
 		},
-		"/seasons/{leagueId}/{year}": {
+		"/seasons/base/{leagueId}/{year}": {
 			"get": {
 				"operationId": "FindSeasonByLeagueAndYear",
 				"responses": {
@@ -432,77 +559,6 @@
 						}
 					}
 				}
-			}
-		},
-		"/seasons/sleeper": {
-			"post": {
-				"operationId": "CreateSleeperSeason",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "number",
-									"format": "double"
-								}
-							}
-						}
-					}
-				},
-				"security": [],
-				"parameters": [],
-				"requestBody": {
-					"required": true,
-					"content": {
-						"application/json": {
-							"schema": {
-								"properties": {
-									"sleeperLeagueId": {
-										"type": "string"
-									},
-									"leagueId": {
-										"type": "number",
-										"format": "double"
-									}
-								},
-								"required": [
-									"sleeperLeagueId",
-									"leagueId"
-								],
-								"type": "object"
-							}
-						}
-					}
-				}
-			}
-		},
-		"/seasons/sleeper/external/{sleeperLeagueId}": {
-			"get": {
-				"operationId": "FindSleeperSeasonBySleeperLeagueId",
-				"responses": {
-					"200": {
-						"description": "Ok",
-						"content": {
-							"application/json": {
-								"schema": {
-									"$ref": "#/components/schemas/Season"
-								}
-							}
-						}
-					}
-				},
-				"security": [],
-				"parameters": [
-					{
-						"in": "path",
-						"name": "sleeperLeagueId",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				]
 			}
 		},
 		"/sleeper/league/{sleeperLeagueId}": {

--- a/swagger.json
+++ b/swagger.json
@@ -434,6 +434,77 @@
 				}
 			}
 		},
+		"/seasons/sleeper": {
+			"post": {
+				"operationId": "CreateSleeperSeason",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "number",
+									"format": "double"
+								}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"properties": {
+									"sleeperLeagueId": {
+										"type": "string"
+									},
+									"leagueId": {
+										"type": "number",
+										"format": "double"
+									}
+								},
+								"required": [
+									"sleeperLeagueId",
+									"leagueId"
+								],
+								"type": "object"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/seasons/sleeper/external/{sleeperLeagueId}": {
+			"get": {
+				"operationId": "FindSleeperSeasonBySleeperLeagueId",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Season"
+								}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "sleeperLeagueId",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
 		"/sleeper/league/{sleeperLeagueId}": {
 			"get": {
 				"operationId": "GetLeagueById",


### PR DESCRIPTION
### What
This PR implements `createSleeperSeason` and `findSleeperSeasonBySleeperLeagueId`

### Details
This was originally branched off of `add-sleeperLeagueId-to-season-schema` before [that approach was deemed flawed](https://github.com/mannalext/FantasyStats/pull/32) and thrown away. The plan was to rebase off main when that got merged. This still needs to be rebased off main, but not until the new approach to adding `sleeperLeagueId` is implemented, and at that point where will be some conflicts that need fixing.

Things of note: 
- `sleeperLeagueId` will be unique at that point, so `findUniqueOrThrow` will be possible
- the issue of needing it to be optional because not all `Season` objects should have a `sleeperLeagueId` will be moot. we will have `SleeperSeasons` and `Seasons` which will inherit from the same db schema and refer back to `leagueId` as one half of the primary key along with `year`