### PR TITLE
Add ability to fetch Sleeper rosters

### DIFF
--- a/__tests__/helpers/mocks/handlers.ts
+++ b/__tests__/helpers/mocks/handlers.ts
@@ -24,4 +24,25 @@ export const handlers = [
   rest.get('https://api.sleeper.app/v1/league/DoesNotExist', (_request, response, context) => {
     return response(context.status(404));
   }),
+  rest.get('https://api.sleeper.app/v1/league/1234/rosters', (_request, response, context) => {
+    return response(
+      context.status(200),
+      context.json([
+        {
+          roster_id: 1,
+          owner_id: '1',
+          league_id: '1234',
+          starters: ['1'],
+          players: ['1'],
+          reserve: ['1'],
+          keepers: ['1'],
+          settings: [1],
+          metadata: ['1'],
+          co_owners: ['1'],
+          player_map: null,
+          taxi: null,
+        },
+      ])
+    );
+  }),
 ];

--- a/__tests__/unit/ports/sleeper-client.test.ts
+++ b/__tests__/unit/ports/sleeper-client.test.ts
@@ -36,4 +36,13 @@ describe('sleeper-client', () => {
       expect(await client.getLeagueById(sleeperLeagueId)).toEqual(sleeperLeague);
     });
   });
+
+  describe('getRostersForLeague', () => {
+    it('should return a list of rosters', async () => {
+      const sleeperLeagueId = '1234';
+      const rosters = await client.getRostersForLeague(sleeperLeagueId);
+
+      expect(rosters.length).toEqual(1);
+    });
+  });
 });

--- a/src/entities/sleeper/sleeper-roster.ts
+++ b/src/entities/sleeper/sleeper-roster.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export class SleeperRoster {
+  rosterId: number;
+  ownerId: string;
+  leagueId: string;
+  starters: string[];
+  players: string[];
+  reserve: string[];
+  keepers: string[];
+  settings: number[];
+  metadata: string[];
+  coOwners: string[];
+  player_map: any; // unimplemented
+  taxi: any; // unimplemented
+
+  constructor(
+    rosterId: number,
+    ownerId: string,
+    leagueId: string,
+    starters: string[],
+    players: string[],
+    reserve: string[],
+    keepers: string[],
+    settings: number[],
+    metadata: string[],
+    coOwners: string[],
+    player_map: any,
+    taxi: any
+  ) {
+    this.rosterId = rosterId;
+    this.ownerId = ownerId;
+    this.leagueId = leagueId;
+    this.starters = starters;
+    this.players = players;
+    this.reserve = reserve;
+    this.keepers = keepers;
+    this.settings = settings;
+    this.metadata = metadata;
+    this.coOwners = coOwners;
+    this.player_map = player_map;
+    this.taxi = taxi;
+  }
+}
+
+export class SleeperRosterDTO {
+  roster_id: number;
+  owner_id: string;
+  league_id: string;
+  starters: string[];
+  players: string[];
+  reserve: string[];
+  keepers: string[];
+  settings: number[];
+  metadata: string[];
+  co_owners: string[];
+  player_map: any; // unimplemented
+  taxi: any; // unimplemented
+
+  constructor(
+    roster_id: number,
+    owner_id: string,
+    league_id: string,
+    starters: string[],
+    players: string[],
+    reserve: string[],
+    keepers: string[],
+    settings: number[],
+    metadata: string[],
+    co_owners: string[],
+    player_map: any,
+    taxi: any
+  ) {
+    this.roster_id = roster_id;
+    this.owner_id = owner_id;
+    this.league_id = league_id;
+    this.starters = starters;
+    this.players = players;
+    this.reserve = reserve;
+    this.keepers = keepers;
+    this.settings = settings;
+    this.metadata = metadata;
+    this.co_owners = co_owners;
+    this.player_map = player_map;
+    this.taxi = taxi;
+  }
+}

--- a/src/ports/sleeper-client/http-sleeper-client.ts
+++ b/src/ports/sleeper-client/http-sleeper-client.ts
@@ -1,4 +1,5 @@
 import { SleeperLeague, SleeperLeagueDTO } from '@entities/sleeper/sleeper-league';
+import { SleeperRoster, SleeperRosterDTO } from '../../entities/sleeper/sleeper-roster';
 import { SleeperClient } from './sleeper-client';
 import axios from 'axios';
 
@@ -18,6 +19,32 @@ export class HttpSleeperClient implements SleeperClient {
   async doesSleeperLeagueExistBySleeperLeagueId(sleeperLeagueId: string): Promise<boolean> {
     const response = await axios.get(`${this.sleeperApiUrl}/league/${sleeperLeagueId}`);
     return !!response.data;
+  }
+
+  async getRostersForLeague(sleeperLeagueId: string): Promise<SleeperRoster[]> {
+    const response = await axios.get(`${this.sleeperApiUrl}/league/${sleeperLeagueId}/rosters`);
+    const sleeperLeagueRosters: SleeperRoster[] = response.data.map((sleeperRosterDTO: SleeperRosterDTO) => {
+      return this.convertSleeperRosterDTOToSleeperRoster(sleeperRosterDTO);
+    });
+
+    return sleeperLeagueRosters;
+  }
+
+  private convertSleeperRosterDTOToSleeperRoster(sleeperRosterDTO: SleeperRosterDTO): SleeperRoster {
+    return {
+      rosterId: sleeperRosterDTO.roster_id,
+      ownerId: sleeperRosterDTO.owner_id,
+      leagueId: sleeperRosterDTO.league_id,
+      starters: sleeperRosterDTO.starters,
+      players: sleeperRosterDTO.players,
+      reserve: sleeperRosterDTO.reserve,
+      keepers: sleeperRosterDTO.keepers,
+      settings: sleeperRosterDTO.settings,
+      metadata: sleeperRosterDTO.metadata,
+      coOwners: sleeperRosterDTO.co_owners,
+      player_map: sleeperRosterDTO.player_map,
+      taxi: sleeperRosterDTO.taxi,
+    };
   }
 
   private convertSleeperLeagueDTOToSleeperLeague(sleeperLeagueDTO: SleeperLeagueDTO): SleeperLeague {

--- a/src/ports/sleeper-client/sleeper-client.ts
+++ b/src/ports/sleeper-client/sleeper-client.ts
@@ -1,6 +1,9 @@
+import { SleeperRoster } from '../../entities/sleeper/sleeper-roster';
 import { SleeperLeague } from '../../entities/sleeper/sleeper-league';
 
 export interface SleeperClient {
   getLeagueById(sleeperLeagueId: string): Promise<SleeperLeague>;
+  getRostersForLeague(sleeperLeagueId: string): Promise<SleeperRoster[]>;
+
   doesSleeperLeagueExistBySleeperLeagueId(sleeperLeagueId: string): Promise<boolean>;
 }

--- a/src/services/sleeper-client/sleeper-client-service.ts
+++ b/src/services/sleeper-client/sleeper-client-service.ts
@@ -1,4 +1,6 @@
 import { SleeperLeague } from '../../entities/sleeper/sleeper-league';
+import { SleeperRoster } from '../../entities/sleeper/sleeper-roster';
+
 import { getPorts } from '../../ports/get-ports';
 
 export class SleeperClientService {
@@ -6,5 +8,10 @@ export class SleeperClientService {
     const ports = await getPorts();
     // TODO: consider validators. do they live here or in the http client?
     return await ports.sleeperClient.getLeagueById(sleeperLeagueId);
+  }
+
+  public async getRostersForLeague(sleeperLeagueId: string): Promise<SleeperRoster[]> {
+    const ports = await getPorts();
+    return await ports.sleeperClient.getRostersForLeague(sleeperLeagueId);
   }
 }


### PR DESCRIPTION
### What
As a part of the ongoing effort for a single vertical slice of functionality, cumulative W/L for all teams in a league, this PR implements `getRostersForLeague` in both the sleeper-client and sleeper-client-service

### Details
This does not translate the roster information fetched from sleeper to a form more suitable for this application, nor does it store the DTO. Both of those things should be done in the future