### PR TITLE
Use prisma migrate to add nullable, unique `sleeperUserId` to owners schema

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,22 +1,23 @@
 module.exports = {
   extends: [
-    "eslint:recommended",
-    "plugin:unicorn/recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:jest/recommended"
+    'eslint:recommended',
+    'plugin:unicorn/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:jest/recommended',
   ],
   overrides: [
     {
-      files: [ "**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)" ],
+      files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
       rules: {
-        "@typescript-eslint/no-non-null-assertion": "off",
-        "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
-        "unicorn/consistent-function-scoping": "off",
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',
+        'unicorn/consistent-function-scoping': 'off',
+        'unicorn/no-null': 'off',
       },
     },
   ],
   rules: {
-    eqeqeq: "error",
+    eqeqeq: 'error',
   },
-  parser: "@typescript-eslint/parser",
+  parser: '@typescript-eslint/parser',
 };

--- a/__tests__/unit/ports/stats-repository.test.ts
+++ b/__tests__/unit/ports/stats-repository.test.ts
@@ -301,7 +301,11 @@ describe('stats-repository', () => {
 
         it('creates an owner', async () => {
           const ownerId = await repo.createOwner('testOwner');
-          expect(await repo.findOwnerById(ownerId)).toEqual({ id: ownerId, displayName: 'testOwner' });
+          expect(await repo.findOwnerById(ownerId)).toEqual({
+            id: ownerId,
+            displayName: 'testOwner',
+            sleeperUserId: null,
+          });
         });
 
         it('increments owner ids for successively created owners', async () => {
@@ -317,7 +321,11 @@ describe('stats-repository', () => {
         describe('and the owner exists', () => {
           it('returns the owner', async () => {
             const ownerId = await repo.createOwner('testOwner');
-            expect(await repo.findOwnerById(ownerId)).toEqual({ id: ownerId, displayName: 'testOwner' });
+            expect(await repo.findOwnerById(ownerId)).toEqual({
+              id: ownerId,
+              displayName: 'testOwner',
+              sleeperUserId: null,
+            });
           });
         });
 

--- a/__tests__/unit/services/stats/owners/create-owner.test.ts
+++ b/__tests__/unit/services/stats/owners/create-owner.test.ts
@@ -10,6 +10,7 @@ describe('createOwner service', () => {
       expect(owner).toEqual({
         id: ownerId,
         displayName: ownerName,
+        sleeperUserId: null,
       });
     });
 

--- a/__tests__/unit/services/stats/owners/find-owner-by-id.test.ts
+++ b/__tests__/unit/services/stats/owners/find-owner-by-id.test.ts
@@ -11,6 +11,7 @@ describe('findOwnerById service', () => {
       expect(owner).toEqual({
         id: ownerId,
         displayName: ownerName,
+        sleeperUserId: null,
       });
     });
   });

--- a/prisma/migrations/20231016030728_add_sleeper_user_id_to_owners_schema/migration.sql
+++ b/prisma/migrations/20231016030728_add_sleeper_user_id_to_owners_schema/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[sleeperUserId]` on the table `owners` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "owners" ADD COLUMN     "sleeperUserId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "owners_sleeperUserId_key" ON "owners"("sleeperUserId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ model leagues {
 model owners {
   id          Int     @id @default(autoincrement())
   displayName String  @map("display_name") @db.VarChar(50)
+  sleeperUserId String? @unique 
   teams       teams[]
 }
 


### PR DESCRIPTION
### What
This PR adds a unique and nullable column to the `owners` table named `sleeperUserId`.

### Details
This is a part of the ongoing effort to implement a vertical slice of functionality of the eventual app (cumulative W/L). An `owner` (user) could belong to leagues across multiple platforms. A single `owner` object, then, must be able to reference multiple platforms. We cannot force them to make a new account for Sleeper, ESPN, etc. The difference here between `season` & `sleeperSeason` is that the `owner` object here can reference multiple external platforms. A `season` that references Sleeper can never reference another platform. This is why we can add the column to the existing table rather than needing to rely on table inheritance.